### PR TITLE
Add click events to AdditionalContent component

### DIFF
--- a/packages/@orchidui-vue/package-lock.json
+++ b/packages/@orchidui-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "flag-icons": "^6.11.1"

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
@@ -100,10 +100,3 @@ export const Default = {
         `,
   }),
 };
-
-{
-  /* custom filter form <template #custom-filter-form="{updateFilter, errors ,values, jsonForm}">
-      filter name:  {{jsonForm[0].name}}
-      <Toggle size="small" :model-value="false" @update:modelValue="updateFilter(jsonForm[0],$event)"/>
-      </template> */
-}

--- a/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
@@ -11,6 +11,7 @@ import {
 
 export default {
   component: DataTable,
+  tags: ["autodocs"],
 };
 
 import { DataTableOptions, Filter } from "../../data/DataTableOptions.sample";
@@ -41,38 +42,38 @@ export const Default = {
           <Theme class="p-8">
             <div>
               <ul>
-                <li v-for="item, key in args.filter">{{key}} : {{item}}</li>
+                <li v-for="(item, key) in args.filter">{{ key }} : {{ item }}</li>
               </ul>
             </div>
             <DataTable id="sample-data-table" :filter="args.filter" :options="args.options" @update:filter="updateFilterData">
-            <template #before>
-              Slot Before
-            </template>  
-             <template #bulk-actions="{selectedRows}">
+              <template #before>
+                Slot Before
+              </template>
+              <template #bulk-actions="{selectedRows}">
                 <Button
-                  label="Publish"
-                  size="small"
-                  is-transparent
-                  left-icon="eye-open"
+                    label="Publish"
+                    size="small"
+                    is-transparent
+                    left-icon="eye-open"
                 />
                 <Button
-                  label="Unpublish"
-                  is-transparent
-                  size="small"
-                  variant="secondary"
-                  left-icon="eye-close"
+                    label="Unpublish"
+                    is-transparent
+                    size="small"
+                    variant="secondary"
+                    left-icon="eye-close"
                 />
                 <Button
-                  label="Delete"
-                  is-transparent
-                  size="small"
-                  variant="destructive"
-                  left-icon="bin"
+                    label="Delete"
+                    is-transparent
+                    size="small"
+                    variant="destructive"
+                    left-icon="bin"
                 />
                 {{ selectedRows }}
               </template>
               <template #col1="{ item }">
-                  <TableCellContent important :title="item.title" :description="item.descriptions"/>
+                <TableCellContent important :title="item.title" :description="item.descriptions"/>
               </template>
               <template #col4="{ data }">
                 <span class="text-oc-text-400 text-sm">{{ data }}</span>
@@ -102,7 +103,7 @@ export const Default = {
 
 {
   /* custom filter form <template #custom-filter-form="{updateFilter, errors ,values, jsonForm}">
-filter name:  {{jsonForm[0].name}}
-<Toggle size="small" :model-value="false" @update:modelValue="updateFilter(jsonForm[0],$event)"/>
-</template> */
+      filter name:  {{jsonForm[0].name}}
+      <Toggle size="small" :model-value="false" @update:modelValue="updateFilter(jsonForm[0],$event)"/>
+      </template> */
 }

--- a/packages/@orchidui-vue/src/Builder/DataTable/OcFilterSearch.vue
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcFilterSearch.vue
@@ -6,6 +6,9 @@ defineEmits({
   addQuery: [],
   toggle: [],
 });
+defineProps({
+  isSearchOnly: Boolean,
+});
 const isSearchOpen = ref(false);
 const query = ref("");
 </script>
@@ -13,7 +16,11 @@ const query = ref("");
 <template>
   <div
     class="transition-all w-full duration-300"
-    :class="isSearchOpen ? 'max-w-[400px]' : 'absolute max-w-0 overflow-hidden'"
+    :class="
+      isSearchOpen || isSearchOnly
+        ? 'max-w-[400px]'
+        : 'absolute max-w-0 overflow-hidden'
+    "
   >
     <div class="flex gap-x-4">
       <Input
@@ -26,7 +33,18 @@ const query = ref("");
         "
       />
 
+      <Button
+        v-if="isSearchOnly"
+        label="Search"
+        variant="secondary"
+        class="shrink-0"
+        @click="
+          $emit('addQuery', query);
+          query = '';
+        "
+      />
       <span
+        v-else
         class="py-3 text-base cursor-pointer flex normal-case items-center font-medium text-oc-text-400"
         @click="
           isSearchOpen = false;
@@ -39,6 +57,7 @@ const query = ref("");
     </div>
   </div>
   <div
+    v-if="!isSearchOnly"
     class="transition-all duration-300"
     :class="!isSearchOpen ? 'max-w-[400px]' : 'max-w-0 overflow-hidden'"
   >

--- a/packages/@orchidui-vue/src/Builder/DataTable/OcFilterSearchFor.vue
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcFilterSearchFor.vue
@@ -5,6 +5,7 @@ defineProps({
 });
 defineEmits({
   removeQuery: [],
+  removeAll: [],
 });
 </script>
 
@@ -15,10 +16,16 @@ defineEmits({
       <Chip
         v-for="query in queries"
         :key="query"
-        variant="gray"
+        variant="accent-1"
         closable
         :label="query"
         @remove="$emit('removeQuery', query)"
+      />
+      <Chip
+        variant="gray"
+        class="cursor-pointer"
+        label="Clear all"
+        @click="$emit('removeAll')"
       />
     </div>
   </TableHeader>

--- a/packages/@orchidui-vue/src/Elements/PageTitle/AdditionalContent/OcAdditionalContent.vue
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/AdditionalContent/OcAdditionalContent.vue
@@ -26,7 +26,7 @@ const props = defineProps({
 });
 
 defineEmits({
-  changeTab: []
+  changeTab: [],
 });
 const copyLink = async () => {
   try {
@@ -56,10 +56,7 @@ const copyLink = async () => {
           <span class="text-oc-text-400">
             {{ description }}<span class="text-oc-text">{{ userId }}</span>
           </span>
-          <PrimaryActions
-            :primary-actions="primaryActions"
-            @copy="copyLink"
-          />
+          <PrimaryActions :primary-actions="primaryActions" @copy="copyLink" />
         </div>
       </template>
     </Title>

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
@@ -161,8 +161,8 @@ export const Default = {
       leftIcon: "plus",
       label: "New Payment Link",
       onClick: () => {
-        console.log('click new payment link')
-      }
+        console.log("click new payment link");
+      },
     },
     secondaryButtonProps: {
       variant: "secondary",
@@ -173,16 +173,16 @@ export const Default = {
           icon: "upload",
           text: "Bulk create",
           onClick: () => {
-            console.log('click bulk create')
-          }
+            console.log("click bulk create");
+          },
         },
         {
           name: "download",
           icon: "download",
           text: "Export",
           onClick: () => {
-            console.log('click download')
-          }
+            console.log("click download");
+          },
         },
       ],
     },

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
@@ -190,13 +190,7 @@ export const Default = {
   render: (args) => ({
     components: { PageTitle, Theme },
     setup() {
-      const onclickPrimary = () => {
-        console.log("primary clicked");
-      };
-      const onclickSecondary = (value) => {
-        console.log("sec clicked", value);
-      };
-      return { args, onclickPrimary, onclickSecondary };
+      return { args };
     },
     template: `
           <Theme>

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.vue
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.vue
@@ -23,7 +23,7 @@ defineProps({
   secondaryButtonProps: Object,
 });
 defineEmits({
-  changeTab: []
+  changeTab: [],
 });
 </script>
 

--- a/packages/@orchidui-vue/src/Form/Button/OcButton.vue
+++ b/packages/@orchidui-vue/src/Form/Button/OcButton.vue
@@ -35,7 +35,7 @@ const additionalAreaSize = computed(() => ({
 
 const shadowContainer = computed(() => ({
   primary: "shadow-[0_1.5px_0_0_var(--oc-primary-500)]",
-  secondary: " shadow-[0_1.5px_0_0] shadow-black/10",
+  secondary: " shadow-[0_1.5px_0_0] shadow-[#E5E5E5]",
   destructive: "shadow-[0_1.5px_0_0_var(--oc-error-500)]",
 }));
 

--- a/packages/@orchidui-vue/src/Form/PhoneInput/OcPhoneInput.vue
+++ b/packages/@orchidui-vue/src/Form/PhoneInput/OcPhoneInput.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Dropdown, Input, Icon } from "@orchid";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 const props = defineProps({
   countryCodes: Array,
@@ -24,6 +24,14 @@ const emit = defineEmits({
 
 const selectedCountryIso = ref(props.initialCountryCode);
 const isDropdownOpened = ref(false);
+const query = ref("");
+const filteredCountryCodes = computed(() =>
+  props.countryCodes
+    .filter((country) =>
+      country.country.toLowerCase().includes(query.value.toLowerCase()),
+    )
+    .sort((a, b) => a.country.localeCompare(b.country)),
+);
 const getCountryObject = (iso) =>
   props.countryCodes.find(
     (country) => country.iso.toLowerCase() === iso.toLowerCase(),
@@ -82,9 +90,16 @@ onMounted(() => {
 
         <template #menu>
           <div class="flex flex-col max-h-[300px] py-2 overflow-y-auto">
+            <div class="px-3 py-1">
+              <Input v-model="query" icon="search" placeholder="Search">
+                <template #icon>
+                  <Icon class="w-5 h-5 text-oc-text-400" name="search" />
+                </template>
+              </Input>
+            </div>
             <div
-              v-for="country in countryCodes"
-              :key="country.code"
+              v-for="(country, i) in filteredCountryCodes"
+              :key="i"
               class="py-3 px-4 flex gap-x-4 items-center hover:bg-oc-gray-50 cursor-pointer"
               @click="changeSelectedCountry(country.iso, country.code)"
             >


### PR DESCRIPTION
Adding clicks events to "preview link button", "dropdown menu items".
Note: This section can be more customizable. For now it covers click events, but it can change icon, text, dropdown items...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Introduced a new `primaryActions` prop to replace the `tooltipContent` prop, enhancing the flexibility of primary actions in the Page Title component.
- Added a `click:primaryActionsDropdown` event to handle user interactions with the primary actions dropdown, improving user experience.
- Updated the `OcPageTitle.stories.js` to include a `dropdownOptions` array, allowing for multiple dropdown options with their respective handlers.

Refactor:
- Replaced the `tooltipContent` prop with `primaryActions` in the `OcAdditionalContent.vue`, `OcPageTitle.vue`, and `OcPrimaryActions.vue` files, streamlining the prop usage across components.
- Updated the `DropdownItem` components to emit the `click:primaryActionsDropdown` event, enhancing event handling.

Style:
- Wrapped the `Icon` component in an `<a>` tag with a `target="_blank"` attribute, improving the visual presentation and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->