### PR TITLE
Added fix to accept for single file upload

### DIFF
--- a/packages/@orchidui-vue/src/Form/SingleFileUpload/SingleFileUpload.vue
+++ b/packages/@orchidui-vue/src/Form/SingleFileUpload/SingleFileUpload.vue
@@ -11,6 +11,7 @@ const props = defineProps({
    * Maximum file size in MB
    */
   maxSize: Number,
+  accept: String,
 });
 const emit = defineEmits(["update:modelValue"]);
 
@@ -134,6 +135,7 @@ const checkFileLink = async (link) => {
           ref="inputRef"
           class="hidden"
           type="file"
+          :accept="accept"
           @change="onChangeFile"
         />
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `accept` property for the Single File Upload component, allowing users to specify the types of files that can be uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->