### PR TITLE
add slot to sub header

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.16",
+  "version": "0.2.18",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Elements/Header/OcHeader.stories.js
+++ b/packages/@orchidui-vue/src/Elements/Header/OcHeader.stories.js
@@ -112,8 +112,12 @@ export const SubHeaderElement = {
               <HeaderLeft class="hidden md:flex">
                 <SampleHeaderLeft is-sub-header/>
               </HeaderLeft>
-              <HeaderCenter class="flex-1" :is-saved="args.isSaved"></HeaderCenter>
-              <HeaderRight :is-saved="args.isSaved"></HeaderRight>
+              <HeaderCenter class="flex-1" :is-saved="args.isSaved">
+              <template #after> <span class="text-oc-text-100 ml-3">---Slot After</span></template>
+              </HeaderCenter>
+              <HeaderRight :is-saved="args.isSaved">
+              <template #before> <span class="text-oc-text-100 ml-3">Slot Before---</span></template>
+              </HeaderRight>
             </SubHeader>
           </Theme>
         `,

--- a/packages/@orchidui-vue/src/Elements/Header/OcHeader.stories.js
+++ b/packages/@orchidui-vue/src/Elements/Header/OcHeader.stories.js
@@ -115,7 +115,7 @@ export const SubHeaderElement = {
               <HeaderCenter class="flex-1" :is-saved="args.isSaved">
               <template #after> <span class="text-oc-text-100 ml-3">---Slot After</span></template>
               </HeaderCenter>
-              <HeaderRight :is-saved="args.isSaved">
+              <HeaderRight :is-saved="args.isSaved" :primary-props="{label: 'Update'}">
               <template #before> <span class="text-oc-text-100 ml-3">Slot Before---</span></template>
               </HeaderRight>
             </SubHeader>

--- a/packages/@orchidui-vue/src/Elements/Header/OcHeaderCenter.vue
+++ b/packages/@orchidui-vue/src/Elements/Header/OcHeaderCenter.vue
@@ -8,6 +8,7 @@ defineEmits(["back"]);
 <template>
   <div class="flex items-center">
     <slot>
+      <slot name="before" />
       <span
         v-if="isSaved"
         class="text-oc-text-100 flex items-center cursor-pointer"
@@ -19,6 +20,7 @@ defineEmits(["back"]);
       <span v-else class="text-oc-text-300 text-sm md:text-base">
         Unsaved changes
       </span>
+      <slot name="after" />
     </slot>
   </div>
 </template>

--- a/packages/@orchidui-vue/src/Elements/Header/OcHeaderRight.vue
+++ b/packages/@orchidui-vue/src/Elements/Header/OcHeaderRight.vue
@@ -2,28 +2,34 @@
 import { Button } from "@/orchidui";
 defineEmits(["save", "cancel"]);
 defineProps({
-  saveLabel: {
-    type: String,
-    default: "Save",
+  primaryProps: {
+    type: Object,
+  },
+  secondaryProps: {
+    type: Object,
   },
 });
 </script>
 <template>
   <div class="flex items-center gap-x-7 ml-auto">
     <slot>
+      <slot name="before" />
       <div class="flex gap-x-3">
         <Button
           class="min-w-[100px]"
           variant="secondary"
           label="Cancel"
+          v-bind="secondaryProps"
           @click="$emit('cancel')"
         />
         <Button
           class="min-w-[100px]"
-          :label="saveLabel"
+          label="Save"
+          v-bind="primaryProps"
           @click="$emit('save')"
         />
       </div>
+      <slot name="after" />
     </slot>
   </div>
 </template>


### PR DESCRIPTION

![Screenshot 2023-11-23 at 17 41 51](https://github.com/hit-pay/orchid/assets/46804248/8d6033a1-0c2d-40af-accc-058d6ea47c72)

Migration Guide :
1. remove props save-label 
2. added button props : 
primaryProps: {
    type: Object,
  },
  secondaryProps: {
    type: Object,
 },

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced named slots in `HeaderCenter` and `HeaderRight` components for custom content insertion before and after the main content.

- **Refactor**
  - Replaced `saveLabel` prop with `primaryProps` and `secondaryProps` to provide more flexibility in button properties.

- **Style**
  - Updated `HeaderCenter` and `HeaderRight` components with new template slots for enhanced customization.

- **Documentation**
  - Updated story files to demonstrate the usage of new slots in header components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->