### PR TITLE
OcDataTable add isCursorPointer option

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
@@ -33,7 +33,7 @@ const emit = defineEmits({
 });
 
 const isSelectable = computed(() => props.options.isSelectable);
-const isCursorPointer = computed(() => props.options.isCursorPointer);
+const isCursorPointer = computed(() => props.options.isCursorPointer ?? true);
 const fields = computed(() => props.options.fields);
 const headers = computed(() => props.options.headers);
 

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
@@ -33,6 +33,7 @@ const emit = defineEmits({
 });
 
 const isSelectable = computed(() => props.options.isSelectable);
+const isCursorPointer = computed(() => props.options.isCursorPointer);
 const fields = computed(() => props.options.fields);
 const headers = computed(() => props.options.headers);
 
@@ -178,12 +179,13 @@ onMounted(() => onScroll());
       <div
         v-for="(field, i) in fields"
         :key="i"
-        class="flex relative group/row md:p-0 py-3 cursor-pointer"
+        class="flex relative group/row md:p-0 py-3"
         :class="{
           'border-b md:border-b-0': fields.length !== i + 1,
           'pl-[40px]': isSelectable,
           'flex-wrap': !isSticky,
           'w-max !p-0': isSticky,
+          'cursor-pointer': isCursorPointer,
         }"
       >
         <TableCell

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCellContent.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCellContent.vue
@@ -13,7 +13,9 @@ defineProps({
       class="overflow-hidden text-ellipsis text-oc-text"
       :class="important ? 'font-medium' : 'font-regular'"
     >
-      <a v-if="href" :href="href" target="_blank" rel="noopener noreferrer">{{ title }}</a>
+      <a v-if="href" :href="href" target="_blank" rel="noopener noreferrer">{{
+        title
+      }}</a>
       <template v-else>{{ title }}</template>
       <span v-if="!title">-</span>
     </span>

--- a/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
+++ b/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
@@ -63,6 +63,7 @@ const DataTableOptions = {
   },
   tableOptions: {
     isSelectable: true,
+    // isCursorPointer: false,
     headers: [
       {
         key: "image",
@@ -85,9 +86,9 @@ const DataTableOptions = {
         variant: "content",
         label: "Table Header",
         title: "col3Title",
+        href: "col3Url",
         description: "col3Description",
         isCopy: true,
-        href: "col3Url",
         class: "w-1/2 md:w-[12%]",
       },
       {

--- a/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
+++ b/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
@@ -63,7 +63,7 @@ const DataTableOptions = {
   },
   tableOptions: {
     isSelectable: true,
-    // isCursorPointer: false,
+    isCursorPointer: true,
     headers: [
       {
         key: "image",


### PR DESCRIPTION
isCursorPointer: true => Apply tailwindcss class 'cursor-pointer' to table body
isCursorPointer: false => Remove css class from table body

The default behaviour is set to True.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tables now support a clickable cursor style by default, enhancing user interaction.

- **Style**
  - Improved visual formatting for table cell content, ensuring a cleaner presentation of data.

- **Documentation**
  - Updated sample data table options to reflect new clickable cursor feature and modified header properties for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->