### PR TITLE
[Improvement] Reactive errors in OcForm builder

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.45",
+  "version": "0.2.47",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Builder/Form/OcFormBuilder.stories.js
+++ b/packages/@orchidui-vue/src/Builder/Form/OcFormBuilder.stories.js
@@ -134,6 +134,13 @@ export const Default = {
                 Errors : {{ errors }}
               </p>
             </div>
+            <Button
+              label="Trigger errors"
+              @click="errors = {
+                phone_number_field: 'Field is invalid format',
+                input: 'Field is required',
+              }"
+            />
             <FormBuilder
                 id="form-builder"
                 class="gap-5"
@@ -179,7 +186,6 @@ export const Default = {
                     </div>
                   </Dropdown>
                 </template>
-                </Input>
               </template>
             </FormBuilder>
           </Theme>

--- a/packages/@orchidui-vue/src/Builder/Form/OcFormBuilder.vue
+++ b/packages/@orchidui-vue/src/Builder/Form/OcFormBuilder.vue
@@ -93,7 +93,7 @@ const modelValues = (name, defaultValue = "") => {
     return props.values[name] ?? defaultValue;
   }
 };
-const errorValues = (name) => {
+const errorValues = computed(() => (name) => {
   if (typeof name === "object") {
     let errorMessage = [];
     name.forEach((formName) => {
@@ -105,7 +105,8 @@ const errorValues = (name) => {
   } else {
     return props.errors[name] ?? "";
   }
-};
+});
+
 const gridDefinitionVariables = computed(() => {
   const parseGridArea = (gridArea) =>
     gridArea

--- a/packages/@orchidui-vue/src/Form/PhoneInput/OcPhoneInput.vue
+++ b/packages/@orchidui-vue/src/Form/PhoneInput/OcPhoneInput.vue
@@ -74,6 +74,19 @@ const changeSelectedCountry = (iso, code) => {
   emit("update:modelValue", [code, props.modelValue?.[1] || ""]);
   isDropdownOpened.value = false;
 };
+
+const countryListRef = ref(null);
+const countryListItemRef = ref([]);
+const scrollToSelectedCountry = () => {
+  setTimeout(() => {
+    const indexSelectedCountry = filteredCountryCodes.value.indexOf(
+      getCountryObject(selectedCountryIso.value),
+    );
+    const countryEl = countryListItemRef.value[indexSelectedCountry];
+    const top = countryEl.offsetTop;
+    countryListRef.value.scrollTo(0, top - 60, { behavior: "smooth" });
+  }, 10);
+};
 </script>
 
 <template>
@@ -96,6 +109,7 @@ const changeSelectedCountry = (iso, code) => {
         v-model="isDropdownOpened"
         :distance="10"
         placement="bottom-start"
+        @update:model-value="scrollToSelectedCountry"
       >
         <div class="flex gap-x-2 items-center">
           <div
@@ -116,8 +130,11 @@ const changeSelectedCountry = (iso, code) => {
         </div>
 
         <template #menu>
-          <div class="flex flex-col max-h-[300px] py-2 overflow-y-auto">
-            <div class="px-3 py-1">
+          <div
+            ref="countryListRef"
+            class="flex flex-col max-h-[300px] py-2 overflow-y-scroll"
+          >
+            <div class="px-3 py-1 sticky top-0 bg-oc-bg-light z-[1000]">
               <Input v-model="query" icon="search" placeholder="Search">
                 <template #icon>
                   <Icon class="w-5 h-5 text-oc-text-400" name="search" />
@@ -126,8 +143,14 @@ const changeSelectedCountry = (iso, code) => {
             </div>
             <div
               v-for="(country, i) in filteredCountryCodes"
+              ref="countryListItemRef"
               :key="i"
               class="py-3 px-4 flex gap-x-4 items-center hover:bg-oc-gray-50 cursor-pointer"
+              :class="
+                selectedCountryIso === country.iso.toLowerCase()
+                  ? 'bg-oc-gray-50 font-medium'
+                  : ''
+              "
               @click="changeSelectedCountry(country.iso, country.code)"
             >
               <div

--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -49,9 +49,7 @@ const emit = defineEmits({
   "update:modelValue": [],
 });
 
-const localValue = ref(
-  props.modelValue ? props.modelValue : props.multiple ? [] : "",
-);
+const localValue = ref();
 
 const query = ref("");
 const isDropdownOpened = ref(false);
@@ -122,6 +120,18 @@ const removeOption = (value) => {
   localValue.value = localValue.value.filter((o) => o !== value);
   emit("update:modelValue", localValue.value);
 };
+
+const initLocalValue = () => {
+  if (props.modelValue === null || props.modelValue === undefined) {
+    localValue.value = props.multiple ? [] : "";
+
+    return;
+  }
+
+  localValue.value = props.modelValue;
+}
+
+initLocalValue()
 </script>
 
 <template>

--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -129,9 +129,9 @@ const initLocalValue = () => {
   }
 
   localValue.value = props.modelValue;
-}
+};
 
-initLocalValue()
+initLocalValue();
 </script>
 
 <template>


### PR DESCRIPTION
<img width="1008" alt="image" src="https://github.com/hit-pay/orchid/assets/40382842/2b7cc73f-ca34-4ec3-8330-62944479f2a3">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Trigger errors" button to simulate form validation errors for testing purposes.

- **Refactor**
  - Updated the error handling logic to use a computed property, enhancing the form's reactivity to validation changes.

- **Bug Fixes**
  - Fixed the initialization process of the `localValue` in the select component to ensure correct default values are set.

- **Documentation**
  - Updated documentation to reflect changes in form error handling and select component behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->