### PR TITLE
Added copyTooltip component + some fixes

### DIFF
--- a/packages/@orchidui-vue/src/DataDisplay/CustomerCard/OcListDetail.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/CustomerCard/OcListDetail.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Icon, Tooltip } from "@/orchidui";
+import { Icon, CopyTooltip } from "@/orchidui";
 
 defineProps({
   label: {
@@ -11,13 +11,6 @@ defineProps({
     default: "",
   },
 });
-const copyToClipboard = async (text) => {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (err) {
-    console.error("Unable to copy text to clipboard. Error: ", err);
-  }
-};
 </script>
 
 <template>
@@ -25,12 +18,7 @@ const copyToClipboard = async (text) => {
     <div class="flex gap-x-2 items-center w-[80px] shrink-0 text-oc-text-400">
       {{ label }}
 
-      <Tooltip position="top" :hide-after="1500" trigger="click" :distance="10">
-        <template #popper>
-          <div class="px-3 py-2 text-oc-text-400 text-sm font-medium">
-            Copied!
-          </div>
-        </template>
+      <CopyTooltip :value="content">
         <template #default="{ isShow }">
           <Icon
             width="14"
@@ -38,10 +26,9 @@ const copyToClipboard = async (text) => {
             class="cursor-pointer transition-all duration-500 group-hover:opacity-100"
             :class="isShow ? 'opacity-100' : 'opacity-0'"
             name="copy"
-            @click="copyToClipboard(content)"
           />
         </template>
-      </Tooltip>
+      </CopyTooltip>
     </div>
 
     <span>{{ content }}</span>

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcListUrl.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcListUrl.vue
@@ -1,17 +1,10 @@
 <script setup lang="ts">
-import { Icon, Tooltip } from "@/orchidui";
+import { Icon, CopyTooltip } from "@/orchidui";
 
-const props = defineProps({
+defineProps({
   title: String,
   url: String,
 });
-const copyToClipboard = async () => {
-  try {
-    await navigator.clipboard.writeText(props.url);
-  } catch (err) {
-    console.error("Unable to copy text to clipboard. Error: ", err);
-  }
-};
 </script>
 
 <template>
@@ -19,18 +12,7 @@ const copyToClipboard = async () => {
     <span class="text-oc-text-400 font-medium">{{ title }}:</span>
     {{ url }}
 
-    <Tooltip
-      position="top"
-      :hide-after="1500"
-      arrow-hidden
-      trigger="click"
-      :distance="10"
-    >
-      <template #popper>
-        <div class="px-3 py-2 text-oc-text-400 text-sm font-medium">
-          Copied!
-        </div>
-      </template>
+    <CopyTooltip :value="url">
       <template #default="{ isShow }">
         <Icon
           width="14"
@@ -38,10 +20,9 @@ const copyToClipboard = async () => {
           class="cursor-pointer transition-all duration-500 group-hover/url:opacity-100"
           :class="isShow ? 'opacity-100' : 'opacity-0'"
           name="copy"
-          @click="copyToClipboard"
         />
       </template>
-    </Tooltip>
+    </CopyTooltip>
   </div>
 </template>
 

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
@@ -1,6 +1,12 @@
 <script setup>
 import { computed, ref } from "vue";
-import { Checkbox, Icon, Tooltip, TableCellContent, Chip } from "@/orchidui";
+import {
+  Checkbox,
+  Icon,
+  CopyTooltip,
+  TableCellContent,
+  Chip,
+} from "@/orchidui";
 import dayjs from "dayjs";
 
 const Variants = {
@@ -161,26 +167,18 @@ const copyToClipboard = async (text) => {
         <div v-else>-</div>
       </slot>
 
-      <Tooltip
+      <CopyTooltip
         v-if="isCopy && hasContentData"
-        position="top"
-        arrow-hidden
-        transition-name="copy"
-        :hide-after="800"
-        trigger="click"
-        :distance="10"
+        :value="data"
+        :tooltip-options="{
+          transitionName: 'copy',
+        }"
       >
         <Icon
           class="cursor-pointer w-5 h-5 group-hover/row:opacity-100 md:opacity-0 ml-2"
           name="copy"
-          @click="copyToClipboard(data)"
         />
-        <template #popper>
-          <div class="px-3 py-2 text-oc-text-400 text-sm font-medium">
-            Copied!
-          </div>
-        </template>
-      </Tooltip>
+      </CopyTooltip>
     </div>
   </div>
 </template>

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.stories.js
@@ -40,6 +40,8 @@ export const Default = {
       ],
     },
     isBack: false,
+    isCopy: false,
+    chipOptions: null,
   },
   render: (args) => ({
     components: { PageTitle, Theme },

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.vue
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcPageTitle.vue
@@ -7,6 +7,8 @@ defineProps({
   description: { type: String },
   primaryButtonProps: Object,
   secondaryButtonProps: Object,
+  chipProps: Object,
+  isCopy: Boolean,
   isBack: { type: Boolean, default: false },
 });
 defineEmits({
@@ -33,7 +35,9 @@ defineEmits({
         <Title
           :title="title"
           :description="description"
-          class="flex-1 overflow-hidden"
+          :chip-props="chipProps"
+          :is-copy="isCopy"
+          class="flex-1"
         />
 
         <slot name="right">

--- a/packages/@orchidui-vue/src/Elements/PageTitle/OcTitle.vue
+++ b/packages/@orchidui-vue/src/Elements/PageTitle/OcTitle.vue
@@ -1,27 +1,45 @@
 <script setup>
+import { Chip, CopyTooltip, Icon } from "@/orchidui";
+
 defineProps({
   title: { type: String, required: true },
   description: { type: String, required: true },
+  chipProps: Object,
+  isCopy: Boolean,
 });
 </script>
 
 <template>
-  <div class="flex text-oc-text justify-center flex-col gap-y-3">
-    <div
-      class="md:text-xl font-medium whitespace-nowrap text-ellipsis overflow-hidden"
-    >
+  <div class="flex text-oc-text justify-center flex-col gap-y-3 max-w-full">
+    <div class="md:text-xl font-medium flex items-center gap-x-3">
       <slot name="title" :title="title">
-        {{ title }}
+        <span class="whitespace-nowrap text-ellipsis overflow-hidden">
+          {{ title }}
+        </span>
       </slot>
+      <Chip v-if="chipProps" v-bind="chipProps" />
     </div>
     <div
       v-if="description"
-      class="text-oc-text-400 text-sm whitespace-nowrap text-ellipsis"
-      :class="$slots.description ? '' : 'overflow-hidden'"
+      class="text-oc-text-400 text-sm group flex items-center gap-x-4"
     >
       <slot name="description" :description="description">
-        {{ description }}
+        <span class="overflow-hidden whitespace-nowrap text-ellipsis">
+          {{ description }}
+        </span>
       </slot>
+
+      <CopyTooltip v-if="isCopy" :value="description">
+        <template #default="{ isShow }">
+          <Icon
+            width="16"
+            height="16"
+            class="cursor-pointer transition-all duration-500 group-hover:opacity-100"
+            :class="isShow ? 'opacity-100' : 'opacity-0'"
+            name="copy"
+          />
+        </template>
+      </CopyTooltip>
     </div>
   </div>
 </template>

--- a/packages/@orchidui-vue/src/Form/Calendar/OcCalendar.vue
+++ b/packages/@orchidui-vue/src/Form/Calendar/OcCalendar.vue
@@ -93,24 +93,28 @@ const selectedMonth = computed(() => {
   }
   return "";
 });
+const isStartDateSet = ref(false);
 
 const selectDay = (day) => {
   const currentMonth = new Date(selectedDate.value);
   currentMonth.setDate(day);
-  if (
-    props.type !== "range" ||
-    Math.abs(
-      currentMonth.getTime() - new Date(selectedEndDate.value).getTime(),
-    ) >
-      Math.abs(
-        currentMonth.getTime() - new Date(selectedStartDate.value).getTime(),
-      )
-  ) {
+  if (!isStartDateSet.value) {
+    isStartDateSet.value = true;
+
     selectedStartDay.value = day;
     selectedStartDate.value = currentMonth;
   } else {
-    selectedEndDay.value = day;
-    selectedEndDate.value = currentMonth;
+    isStartDateSet.value = false;
+    if (selectedStartDate.value.getTime() >= currentMonth.getTime()) {
+      const nextDay = new Date(selectedStartDate.value);
+      nextDay.setDate(nextDay.getDate() + 1);
+
+      selectedEndDate.value = nextDay;
+      selectedEndDay.value = nextDay.getDate();
+    } else {
+      selectedEndDay.value = day;
+      selectedEndDate.value = currentMonth;
+    }
   }
 };
 

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.js
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.js
@@ -1,0 +1,3 @@
+import CopyTooltip from "./OcCopyTooltip.vue";
+
+export { CopyTooltip };

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.stories.js
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.stories.js
@@ -1,0 +1,28 @@
+import OcCopyTooltip from "@/orchidui/Overlay/CopyTooltip/OcCopyTooltip.vue";
+
+export default {
+  component: OcCopyTooltip,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    text: "Text to copy",
+    tooltipText: "Copied!",
+  },
+  render: (args) => ({
+    components: { OcCopyTooltip },
+    setup() {
+      return { args };
+    },
+    template: `
+          <div class="w-full pt-8">
+            <OcCopyTooltip
+                :value="args.text"
+                :tooltip-text="args.tooltipText"
+                :tooltip-options="args.tooltipOptions"
+            />
+          </div>
+        `,
+  }),
+};

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { Icon, Tooltip } from "@/orchidui";
+
+defineProps({
+  value: String,
+  tooltipText: {
+    type: String,
+    default: "Copied!",
+  },
+  tooltipOptions: Object,
+});
+const copyToClipboard = async (text) => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.error("Unable to copy text to clipboard. Error: ", err);
+  }
+};
+</script>
+
+<template>
+  <Tooltip
+    position="top"
+    :hide-after="1500"
+    arrow-hidden
+    trigger="click"
+    :distance="10"
+    v-bind="tooltipOptions"
+  >
+    <template #popper>
+      <div class="px-3 py-2 text-oc-text-400 text-sm font-medium">
+        {{ tooltipText }}
+      </div>
+    </template>
+    <template #default="{ isShow }">
+      <div @click="copyToClipboard(value)">
+        <slot :is-show="isShow">
+          <Icon
+            width="14"
+            height="14"
+            class="cursor-pointer transition-all duration-500"
+            name="copy"
+          />
+        </slot>
+      </div>
+    </template>
+  </Tooltip>
+</template>

--- a/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
+++ b/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
@@ -41,7 +41,7 @@ const onClickOutside = () => {
 </script>
 
 <template>
-  <span v-click-outside="onClickOutside" class="flex" @click.stop>
+  <span v-click-outside="onClickOutside" class="flex">
     <Popper
       ref="popper"
       :placement="placement"

--- a/packages/@orchidui-vue/src/index.js
+++ b/packages/@orchidui-vue/src/index.js
@@ -30,6 +30,7 @@ export * from "./Overlay/Modal/OcModal.js";
 export * from "./Overlay/ConfirmationModal/OcConfirmationModal.js";
 export * from "./Overlay/Popper/OcPopper.js";
 export * from "./Overlay/SupportMenu/OcSupportMenu.js";
+export * from "./Overlay/CopyTooltip/OcCopyTooltip.js";
 
 export * from "./Theme/OcTheme.js";
 

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -64,7 +64,7 @@
   --oc-success-200: #b8e9d2;
   --oc-success-300: #89dbb5;
   --oc-success-400: #59cc97;
-  --oc-success-500: #4dab80;
+  --oc-success-500: #2BC37D;
 
   --oc-warning-50-tr: #f4b8401a;
   --oc-warning-50: #fff9ec;
@@ -92,26 +92,26 @@
   --button-secondary-hover: linear-gradient(180deg, #fff 0%, #fafafa 100%);
   --button-secondary-pressed: linear-gradient(180deg, #fafafa 0%, #fff 100%);
   --button-secondary-disabled: linear-gradient(
-    180deg,
-    #fcfcfc 0%,
-    #f7f7f7 100%
+                  180deg,
+                  #fcfcfc 0%,
+                  #f7f7f7 100%
   );
 
   --button-destructive-default: linear-gradient(
-    180deg,
-    #e44e5c 0%,
-    #cc2334 100%
+                  180deg,
+                  #e44e5c 0%,
+                  #cc2334 100%
   );
   --button-destructive-hover: linear-gradient(180deg, #e44e5c 0%, #dc3747 100%);
   --button-destructive-pressed: linear-gradient(
-    180deg,
-    #dc3747 0%,
-    #e44e5c 100%
+                  180deg,
+                  #dc3747 0%,
+                  #e44e5c 100%
   );
   --button-destructive-disabled: linear-gradient(
-    180deg,
-    #c66c75 0%,
-    #a84851 100%
+                  180deg,
+                  #c66c75 0%,
+                  #a84851 100%
   );
 
   /* utility */
@@ -125,7 +125,7 @@
 
   --oc-shadow-normal: 0px 3px 22px 0px rgba(38, 42, 50, 0.09);
   --oc-shadow-tooltip: 0px 3px 22px 0px rgba(38, 42, 50, 0.09),
-    0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  0px 1px 3px 0px rgba(0, 0, 0, 0.1);
   --oc-shadow-right-sticky: 2px 0px 2px 0px rgba(0, 0, 0, 0.08);
   --oc-shadow-left-sticky: -2px 0px 2px 0px rgba(0, 0, 0, 0.08);
 }
@@ -222,25 +222,25 @@
   --button-secondary-hover: linear-gradient(180deg, #fff 0%, #fafafa 100%);
   --button-secondary-pressed: linear-gradient(180deg, #f1f1f1 0%, #fff 100%);
   --button-secondary-disabled: linear-gradient(
-    180deg,
-    #fcfcfc 0%,
-    #f7f7f7 100%
+                  180deg,
+                  #fcfcfc 0%,
+                  #f7f7f7 100%
   );
 
   --button-destructive-default: linear-gradient(
-    180deg,
-    #e44e5c 0%,
-    #cc2334 100%
+                  180deg,
+                  #e44e5c 0%,
+                  #cc2334 100%
   );
   --button-destructive-hover: linear-gradient(180deg, #e44e5c 0%, #dc3747 100%);
   --button-destructive-pressed: linear-gradient(
-    180deg,
-    #dc3747 0%,
-    #e44e5c 100%
+                  180deg,
+                  #dc3747 0%,
+                  #e44e5c 100%
   );
   --button-destructive-disabled: linear-gradient(
-    180deg,
-    #c66c75 0%,
-    #a84851 100%
+                  180deg,
+                  #c66c75 0%,
+                  #a84851 100%
   );
 }


### PR DESCRIPTION
Added chip and copy to the page-title
Fixed dropdown closable
Fixed chip success color
Fixed date-picker date selection
Added copyTooltip replaced all copy tooltips into this component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `CopyTooltip` component for easy text copying across various components.
	- Added `isCopy` and `chipOptions` properties to `PageTitle` components for enhanced functionality.

- **Enhancements**
	- Upgraded visual feedback for button interactions with refined color values and gradients.

- **Refactor**
	- Replaced `Tooltip` with `CopyTooltip` in multiple components to streamline user experience.
	- Removed redundant `copyToClipboard` functions due to new `CopyTooltip` integration.

- **Bug Fixes**
	- Fixed event handling by removing unnecessary `@click.stop` listener in `Dropdown` component.

- **Documentation**
	- Added story for `CopyTooltip` to demonstrate usage and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->