### PR TITLE
CSS fix: Make ocDropdown inherit width from parent

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.151",
+  "version": "0.2.153",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.153",
+  "version": "0.2.154",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCellContent.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCellContent.vue
@@ -10,7 +10,7 @@ defineProps({
 <template>
   <div class="flex flex-col gap-y-1 whitespace-nowrap overflow-hidden">
     <span
-      class="overflow-hidden text-ellipsis text-oc-text"
+      class="overflow-hidden text-ellipsis text-oc-text truncate"
       :class="important ? 'font-medium' : 'font-regular'"
     >
       <a v-if="href" :href="href" target="_blank" rel="noopener noreferrer">{{
@@ -19,7 +19,9 @@ defineProps({
       <template v-else>{{ title }}</template>
       <span v-if="!title">-</span>
     </span>
-    <span class="overflow-hidden text-ellipsis text-oc-text-400 text-sm">
+    <span
+      class="overflow-hidden text-ellipsis text-oc-text-400 text-sm truncate"
+    >
       {{ description }}
       <span v-if="!description">-</span>
     </span>

--- a/packages/@orchidui-vue/src/Form/DatePicker/DatePicker.vue
+++ b/packages/@orchidui-vue/src/Form/DatePicker/DatePicker.vue
@@ -93,7 +93,7 @@ const resetCalendar = () => {
 };
 
 const defaultDateRange = () => {
-  if (props.maxDate === dayjs().format(props.dateFormat)) {
+  if (props.maxDate === dayjs().add(1, "day").format(props.dateFormat)) {
     return [
       dayjs().subtract(3, "day").toDate(),
       dayjs().subtract(1, "day").toDate(),


### PR DESCRIPTION
ocDropdown doesn't inherit width from parent.
It causes issues with components like ocTimePicker.
![image](https://github.com/hit-pay/orchid/assets/47066872/d830d20e-2f5d-45c6-8b0c-292a49633dbc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Dropdown component with enhanced width inheritance for better visual integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->