### PR TITLE
Add support for copy blob type

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.155",
+  "version": "0.2.157",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { Icon, Tooltip } from "@/orchidui";
 
-defineProps({
-  value: String,
+const props = defineProps({
+  value: [String, Blob],
   tooltipText: {
     type: String,
     default: "Copied!",
@@ -11,7 +11,15 @@ defineProps({
 });
 const copyToClipboard = async (text) => {
   try {
-    await navigator.clipboard.writeText(text);
+    if (props.value instanceof Blob) {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          [props.value.type]: props.value,
+        }),
+      ]);
+    } else {
+      await navigator.clipboard.writeText(text);
+    }
   } catch (err) {
     console.error("Unable to copy text to clipboard. Error: ", err);
   }
@@ -24,7 +32,7 @@ const copyToClipboard = async (text) => {
     :hide-after="1500"
     arrow-hidden
     trigger="click"
-    :distance="10"
+    :distance="20"
     v-bind="tooltipOptions"
   >
     <template #popper>

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
@@ -9,16 +9,16 @@ const props = defineProps({
   },
   tooltipOptions: Object,
 });
-const copyToClipboard = async (text) => {
+const copyToClipboard = async (data) => {
   try {
     if (props.value instanceof Blob) {
       await navigator.clipboard.write([
         new ClipboardItem({
-          [props.value.type]: props.value,
+          [data.type]: data,
         }),
       ]);
     } else {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(data);
     }
   } catch (err) {
     console.error("Unable to copy text to clipboard. Error: ", err);

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Icon, Tooltip } from "@/orchidui";
 
-const props = defineProps({
+defineProps({
   value: [String, Blob],
   tooltipText: {
     type: String,
@@ -11,7 +11,7 @@ const props = defineProps({
 });
 const copyToClipboard = async (data) => {
   try {
-    if (props.value instanceof Blob) {
+    if (data instanceof Blob) {
       await navigator.clipboard.write([
         new ClipboardItem({
           [data.type]: data,

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltipBlob.stories.js
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltipBlob.stories.js
@@ -1,0 +1,38 @@
+import OcCopyTooltip from "@/orchidui/Overlay/CopyTooltip/OcCopyTooltip.vue";
+import OcButton from "@/orchidui/Form/Button/OcButton.vue";
+
+export default {
+  component: OcCopyTooltip,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    value: "",
+    tooltipText: "Copied!",
+    tooltipOptions: { distance: 40 },
+  },
+  render: (args) => ({
+    components: { OcCopyTooltip, OcButton },
+    setup() {
+      const url =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII";
+
+      fetch(url).then(async (res) => (args.value = await res.blob()));
+
+      return { args };
+    },
+    template: `
+          <div class="w-full pt-8">
+            <OcCopyTooltip
+                v-if="args.value"
+                :value="args.value"
+                :tooltip-text="args.tooltipText"
+                :tooltip-options="args.tooltipOptions"
+            >
+              <OcButton>Copy Blob</OcButton>
+            </OcCopyTooltip>
+          </div>
+        `,
+  }),
+};

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltipBlob.stories.js
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltipBlob.stories.js
@@ -25,7 +25,6 @@ export const Default = {
     template: `
           <div class="w-full pt-8">
             <OcCopyTooltip
-                v-if="args.value"
                 :value="args.value"
                 :tooltip-text="args.tooltipText"
                 :tooltip-options="args.tooltipOptions"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The copy tooltip now supports copying text and files (blobs) to the clipboard.

- **Enhancements**
  - Increased the default distance of tooltips for better visibility and user experience.

- **Documentation**
  - Added a new story to demonstrate how to use the copy tooltip with blob data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->