### PR TITLE
Change color option in BarChart

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.2.159",
+  "version": "0.2.160",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
@@ -6,8 +6,14 @@ export default {
 };
 
 export const barChart = {
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["primary", "purple"],
+    },
+  },
   args: {
-    color: "#B14AED",
+    color: "primary",
     showGrid: false,
     showTooltip: true,
     showLegend: true,

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
@@ -7,13 +7,13 @@ export default {
 
 export const barChart = {
   argTypes: {
-    color: {
+    variant: {
       control: "select",
       options: ["primary", "purple"],
     },
   },
   args: {
-    color: "primary",
+    variant: "primary",
     showGrid: false,
     showTooltip: true,
     showLegend: true,
@@ -49,7 +49,7 @@ export const barChart = {
           <div>
             <OcBarChart
                 class="h-[300px]"
-                :color="args.color"
+                :variant="args.variant"
                 :show-grid="args.showGrid"
                 :show-tooltip="args.showTooltip"
                 :show-legend="args.showLegend"

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
@@ -7,7 +7,10 @@ import * as echarts from "echarts";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 const props = defineProps({
-  color: String,
+  color: {
+    type: String,
+    validator: (value) => ["primary", "purple"].includes(value),
+  },
   showTooltip: Boolean,
   showLegend: Boolean,
   showGrid: Boolean,
@@ -18,6 +21,11 @@ const props = defineProps({
   tooltipFormatter: Function,
   tooltipCurrency: String,
 });
+
+const colors = {
+  primary: "#2465DE",
+  purple: "#B14AED",
+};
 
 const options = computed(() => ({
   xAxis: {
@@ -97,12 +105,12 @@ const options = computed(() => ({
       smooth: true,
       showSymbol: false,
       itemStyle: {
-        color: props.color,
+        color: colors[props.color],
         opacity: 0.5,
       },
       emphasis: {
         itemStyle: {
-          color: props.color,
+          color: colors[props.color],
           opacity: 1,
         },
       },

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
@@ -7,7 +7,7 @@ import * as echarts from "echarts";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 const props = defineProps({
-  color: {
+  variant: {
     type: String,
     validator: (value) => ["primary", "purple"].includes(value),
   },
@@ -22,7 +22,7 @@ const props = defineProps({
   tooltipCurrency: String,
 });
 
-const colors = {
+const variants = {
   primary: "#2465DE",
   purple: "#B14AED",
 };
@@ -105,12 +105,12 @@ const options = computed(() => ({
       smooth: true,
       showSymbol: false,
       itemStyle: {
-        color: colors[props.color],
+        color: variants[props.variant],
         opacity: 0.5,
       },
       emphasis: {
         itemStyle: {
-          color: colors[props.color],
+          color: variants[props.variant],
           opacity: 1,
         },
       },

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
@@ -6,8 +6,14 @@ export default {
 };
 
 export const barRace = {
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["primary", "purple"],
+    },
+  },
   args: {
-    color: "#2465DE",
+    color: "primary",
     showGrid: false,
     showTooltip: true,
     showLegend: true,

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
@@ -7,13 +7,13 @@ export default {
 
 export const barRace = {
   argTypes: {
-    color: {
+    variant: {
       control: "select",
       options: ["primary", "purple"],
     },
   },
   args: {
-    color: "primary",
+    variant: "primary",
     showGrid: false,
     showTooltip: true,
     showLegend: true,
@@ -37,7 +37,7 @@ export const barRace = {
           <div>
             <OcBarRaceChart
                 class="h-[300px]"
-                :color="args.color"
+                :variant="args.variant"
                 :show-grid="args.showGrid"
                 :show-tooltip="args.showTooltip"
                 :show-legend="args.showLegend"

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -17,7 +17,7 @@ import * as echarts from "echarts";
 import { computed, onMounted, ref, watch, onUnmounted } from "vue";
 
 const props = defineProps({
-  color: {
+  variant: {
     type: String,
     validator: (value) => ["primary", "purple"].includes(value),
   },
@@ -31,7 +31,7 @@ const props = defineProps({
   tooltipFormatter: Function,
 });
 
-const colors = {
+const variants = {
   primary: "#2465DE",
   purple: "#B14AED",
 };
@@ -112,13 +112,13 @@ const options = computed(() => ({
       },
       barGap: 0,
       itemStyle: {
-        color: colors[props.color],
+        color: variants[props.variant],
         opacity: 0.2,
         borderRadius: [0, 4, 4, 0],
       },
       emphasis: {
         itemStyle: {
-          color: colors[props.color],
+          color: variants[props.variant],
         },
       },
     },
@@ -134,7 +134,7 @@ const options = computed(() => ({
       },
       barGap: "-100%",
       itemStyle: {
-        color: colors[props.color],
+        color: variants[props.variant],
       },
     },
   ],

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -134,7 +134,7 @@ const options = computed(() => ({
       },
       barGap: "-100%",
       itemStyle: {
-        color: colors[props.color] || props.color,
+        color: colors[props.color],
       },
     },
   ],

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -17,7 +17,10 @@ import * as echarts from "echarts";
 import { computed, onMounted, ref, watch, onUnmounted } from "vue";
 
 const props = defineProps({
-  color: String,
+  color: {
+    type: String,
+    validator: (value) => ["primary", "purple"].includes(value),
+  },
   showTooltip: Boolean,
   showLegend: Boolean,
   showGrid: Boolean,
@@ -27,6 +30,11 @@ const props = defineProps({
   yAxisFormatter: Function,
   tooltipFormatter: Function,
 });
+
+const colors = {
+  primary: "#2465DE",
+  purple: "#B14AED",
+};
 
 const options = computed(() => ({
   xAxis: {
@@ -104,13 +112,13 @@ const options = computed(() => ({
       },
       barGap: 0,
       itemStyle: {
-        color: props.color,
+        color: colors[props.color],
         opacity: 0.2,
         borderRadius: [0, 4, 4, 0],
       },
       emphasis: {
         itemStyle: {
-          color: props.color,
+          color: colors[props.color],
         },
       },
     },
@@ -126,12 +134,7 @@ const options = computed(() => ({
       },
       barGap: "-100%",
       itemStyle: {
-        color: props.color,
-      },
-      emphasis: {
-        itemStyle: {
-          color: props.color,
-        },
+        color: colors[props.color] || props.color,
       },
     },
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced selectable color themes for Bar and Bar Race charts with "primary" and "purple" options.
  - Added new chart customization options including grid visibility, tooltip, and legend toggling for Bar Race charts.

- **Refactor**
  - Enhanced color property handling for charts to use named color themes instead of hex values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->