### PR TITLE
Add Dummy Data component

### DIFF
--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
@@ -39,6 +39,7 @@ export const barChart = {
       return (value / 1000).toFixed(1) + "K";
     },
     tooltipCurrency: "SGD",
+    dummyData: false,
   },
   render: (args) => ({
     components: { OcBarChart },
@@ -57,6 +58,7 @@ export const barChart = {
                 :label-data="args.labelData"
                 :tooltip-currency="args.tooltipCurrency"
                 :y-axis-formatter="args.yAxisFormatter"
+                :dummy-data="args.dummyData"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.stories.js
@@ -40,6 +40,7 @@ export const barChart = {
     },
     tooltipCurrency: "SGD",
     dummyData: false,
+    dummyDataDescription: undefined,
   },
   render: (args) => ({
     components: { OcBarChart },
@@ -59,6 +60,7 @@ export const barChart = {
                 :tooltip-currency="args.tooltipCurrency"
                 :y-axis-formatter="args.yAxisFormatter"
                 :dummy-data="args.dummyData"
+                :dummy-data-description="args.dummyDataDescription"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="w-full relative">
     <div ref="barChart" class="h-full" />
-    <dummy-data v-if="dummyData" absolute>
-      <slot name="dummy-data-description">
-        Demo reports will be replaced once <br />
-        you made transactions
-      </slot>
-    </dummy-data>
+    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
   </div>
 </template>
 
@@ -30,6 +25,7 @@ const props = defineProps({
   tooltipFormatter: Function,
   tooltipCurrency: String,
   dummyData: Boolean,
+  dummyDataDescription: String,
 });
 
 const variants = {

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="w-full relative">
     <div ref="barChart" class="h-full" />
-    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
+    <dummy-data
+      v-if="dummyData"
+      :description="dummyDataDescription"
+      isAbsolute
+    />
   </div>
 </template>
 

--- a/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarChart/OcBarChart.vue
@@ -1,10 +1,19 @@
 <template>
-  <div ref="barChart" class="w-full" />
+  <div class="w-full relative">
+    <div ref="barChart" class="h-full" />
+    <dummy-data v-if="dummyData" absolute>
+      <slot name="dummy-data-description">
+        Demo reports will be replaced once <br />
+        you made transactions
+      </slot>
+    </dummy-data>
+  </div>
 </template>
 
 <script setup lang="ts">
 import * as echarts from "echarts";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { DummyData } from "@/orchidui";
 
 const props = defineProps({
   variant: {
@@ -20,6 +29,7 @@ const props = defineProps({
   xAxisFormatter: Function,
   tooltipFormatter: Function,
   tooltipCurrency: String,
+  dummyData: Boolean,
 });
 
 const variants = {

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
@@ -28,6 +28,7 @@ export const barRace = {
       "Joggers",
     ],
     dummyData: false,
+    dummyDataDescription: undefined,
   },
   render: (args) => ({
     components: { OcBarRaceChart },
@@ -46,6 +47,7 @@ export const barRace = {
                 :label-data="args.labelData"
                 :legend-data="args.legendData"
                 :dummy-data="args.dummyData"
+                :dummy-data-description="args.dummyDataDescription"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
@@ -27,6 +27,7 @@ export const barRace = {
       "Joggers",
       "Joggers",
     ],
+    dummyData: false,
   },
   render: (args) => ({
     components: { OcBarRaceChart },
@@ -44,6 +45,7 @@ export const barRace = {
                 :chart-data="args.chartData"
                 :label-data="args.labelData"
                 :legend-data="args.legendData"
+                :dummy-Data="args.dummyData"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.stories.js
@@ -45,7 +45,7 @@ export const barRace = {
                 :chart-data="args.chartData"
                 :label-data="args.labelData"
                 :legend-data="args.legendData"
-                :dummy-Data="args.dummyData"
+                :dummy-data="args.dummyData"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -9,12 +9,7 @@
       </div>
     </div>
     <div ref="barChart" class="h-[100%]" />
-    <dummy-data v-if="dummyData" absolute>
-      <slot name="dummy-data-description">
-        Demo reports will be replaced once <br />
-        you made transactions
-      </slot>
-    </dummy-data>
+    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
   </div>
 </template>
 
@@ -37,6 +32,7 @@ const props = defineProps({
   yAxisFormatter: Function,
   tooltipFormatter: Function,
   dummyData: Boolean,
+  dummyDataDescription: String,
 });
 
 const variants = {

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="grid grid-cols-2">
-    <div class="pt-4 pb-7 flex flex-col h-[100%]">
+  <div class="grid grid-cols-2 relative">
+    <div class="pt-4 pb-7 flex flex-col h-full">
       <div
         v-for="item in legendData"
         class="text-[14px] flex flex-1 items-center justify-start"
@@ -9,12 +9,19 @@
       </div>
     </div>
     <div ref="barChart" class="h-[100%]" />
+    <dummy-data v-if="dummyData" absolute>
+      <slot name="dummy-data-description">
+        Demo reports will be replaced once <br />
+        you made transactions
+      </slot>
+    </dummy-data>
   </div>
 </template>
 
 <script setup lang="ts">
 import * as echarts from "echarts";
 import { computed, onMounted, ref, watch, onUnmounted } from "vue";
+import { DummyData } from "@/orchidui";
 
 const props = defineProps({
   variant: {
@@ -29,6 +36,7 @@ const props = defineProps({
   legendData: Array,
   yAxisFormatter: Function,
   tooltipFormatter: Function,
+  dummyData: Boolean,
 });
 
 const variants = {

--- a/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
+++ b/packages/@orchidui-vue/src/Charts/BarRaceChart/OcBarRaceChart.vue
@@ -9,7 +9,11 @@
       </div>
     </div>
     <div ref="barChart" class="h-[100%]" />
-    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
+    <dummy-data
+      v-if="dummyData"
+      :description="dummyDataDescription"
+      isAbsolute
+    />
   </div>
 </template>
 

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
@@ -27,6 +27,7 @@ export const Line = {
       "OCT'23",
       "NOV'23",
     ],
+    dummyData: true,
   },
   render: (args) => ({
     components: { LineChart },
@@ -42,6 +43,7 @@ export const Line = {
                 :show-legend="args.showLegend"
                 :chart-data="args.chartData"
                 :label-data="args.labelData"
+                :dummy-data="args.dummyData"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
@@ -28,6 +28,7 @@ export const Line = {
       "NOV'23",
     ],
     dummyData: false,
+    dummyDataDescription: undefined,
   },
   render: (args) => ({
     components: { LineChart },
@@ -44,6 +45,7 @@ export const Line = {
                 :chart-data="args.chartData"
                 :label-data="args.labelData"
                 :dummy-data="args.dummyData"
+                :dummy-data-description="args.dummyDataDescription"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.stories.js
@@ -27,7 +27,7 @@ export const Line = {
       "OCT'23",
       "NOV'23",
     ],
-    dummyData: true,
+    dummyData: false,
   },
   render: (args) => ({
     components: { LineChart },

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="w-full relative">
     <div ref="lineChart" class="h-full" />
-    <dummy-data v-if="dummyData" absolute>
-      <slot name="dummy-data-description">
-        Demo reports will be replaced once <br />
-        you made transactions
-      </slot>
-    </dummy-data>
+    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
   </div>
 </template>
 
@@ -22,6 +17,7 @@ const props = defineProps({
   chartData: Array,
   labelData: Array,
   dummyData: Boolean,
+  dummyDataDescription: String,
 });
 const markLineData = ref({
   index: 0,

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
@@ -1,10 +1,19 @@
 <template>
-  <div ref="lineChart" class="w-full" />
+  <div class="w-full relative">
+    <div ref="lineChart" class="h-full" />
+    <dummy-data v-if="dummyData" absolute>
+      <slot name="dummy-data-description">
+        Demo reports will be replaced once <br />
+        you made transactions
+      </slot>
+    </dummy-data>
+  </div>
 </template>
 
 <script setup lang="ts">
 import * as echarts from "echarts";
 import { computed, onMounted, ref, watch } from "vue";
+import { DummyData } from "@/orchidui";
 
 const props = defineProps({
   showTooltip: Boolean,
@@ -12,6 +21,7 @@ const props = defineProps({
   showGrid: Boolean,
   chartData: Array,
   labelData: Array,
+  dummyData: Boolean,
 });
 const markLineData = ref({
   index: 0,

--- a/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
+++ b/packages/@orchidui-vue/src/Charts/LineChart/OcLineChart.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="w-full relative">
     <div ref="lineChart" class="h-full" />
-    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
+    <dummy-data
+      v-if="dummyData"
+      :description="dummyDataDescription"
+      isAbsolute
+    />
   </div>
 </template>
 

--- a/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.stories.js
@@ -38,6 +38,7 @@ export const pieChart = {
       },
     ],
     dummyData: false,
+    dummyDataDescription: undefined,
   },
   render: (args) => ({
     components: { PieChart },
@@ -53,6 +54,7 @@ export const pieChart = {
                 :show-legend="args.showLegend"
                 :chart-data="args.chartData"
                 :dummy-data="args.dummyData"
+                :dummy-data-description="args.dummyDataDescription"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.stories.js
+++ b/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.stories.js
@@ -5,7 +5,7 @@ export default {
   tags: ["autodocs"],
 };
 
-export const Line = {
+export const pieChart = {
   args: {
     showGrid: false,
     showTooltip: true,
@@ -37,6 +37,7 @@ export const Line = {
         itemStyle: { color: "#E5E6EA" },
       },
     ],
+    dummyData: false,
   },
   render: (args) => ({
     components: { PieChart },
@@ -51,6 +52,7 @@ export const Line = {
                 :show-tooltip="args.showTooltip"
                 :show-legend="args.showLegend"
                 :chart-data="args.chartData"
+                :dummy-data="args.dummyData"
             />
           </div>
         `,

--- a/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
+++ b/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
@@ -36,12 +36,7 @@
         </Tooltip>
       </div>
     </div>
-    <dummy-data v-if="dummyData" absolute>
-      <slot name="dummy-data-description">
-        Demo reports will be replaced once <br />
-        you made transactions
-      </slot>
-    </dummy-data>
+    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
   </div>
 </template>
 
@@ -56,6 +51,7 @@ const props = defineProps({
   showGrid: Boolean,
   chartData: Array,
   dummyData: Boolean,
+  dummyDataDescription: String,
 });
 const legendSelected = ref({
   stack_cards: true,

--- a/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
+++ b/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
@@ -36,7 +36,11 @@
         </Tooltip>
       </div>
     </div>
-    <dummy-data v-if="dummyData" :description="dummyDataDescription" absolute />
+    <dummy-data
+      v-if="dummyData"
+      :description="dummyDataDescription"
+      isAbsolute
+    />
   </div>
 </template>
 

--- a/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
+++ b/packages/@orchidui-vue/src/Charts/PieChart/OcPieChart.vue
@@ -1,45 +1,53 @@
 <template>
-  <div class="flex flex-col items-center">
-    <div ref="pieChart" class="h-full w-full" />
+  <div>
+    <div class="flex flex-col items-center relative h-full w-full">
+      <div ref="pieChart" class="h-full w-full" />
 
-    <!--  Here we are using custom legend with toggleLegendName(name) for saving logic of buttons  -->
-    <div v-if="showLegend" class="flex gap-x-5">
-      <Tooltip
-        v-for="item in options.series[0].data"
-        :key="item.name"
-        position="top"
-        class="flex items-center"
-        :distance="10"
-        @click="toggleLegendName(item.name)"
-      >
-        <template #default>
-          <div
-            class="flex items-center gap-x-2 cursor-pointer"
-            :class="!legendSelected[item.name] && 'grayscale'"
-          >
+      <!--  Here we are using custom legend with toggleLegendName(name) for saving logic of buttons  -->
+      <div v-if="showLegend" class="flex gap-x-5">
+        <Tooltip
+          v-for="item in options.series[0].data"
+          :key="item.name"
+          position="top"
+          class="flex items-center"
+          :distance="10"
+          @click="toggleLegendName(item.name)"
+        >
+          <template #default>
             <div
-              class="w-3 h-3 rounded-full"
-              :style="{ background: item.itemStyle.color }"
-            />
-            <img v-if="item.name" :src="legendImages[item.name]" />
-            <span v-else>Other</span>
-          </div>
-        </template>
-        <template #popper>
-          <div
-            class="py-2 text-sm text-oc-text-400 font-medium px-3 max-w-[217px]"
-          >
-            {{ legendTooltipText[item.name] }}
-          </div>
-        </template>
-      </Tooltip>
+              class="flex items-center gap-x-2 cursor-pointer"
+              :class="!legendSelected[item.name] && 'grayscale'"
+            >
+              <div
+                class="w-3 h-3 rounded-full"
+                :style="{ background: item.itemStyle.color }"
+              />
+              <img v-if="item.name" :src="legendImages[item.name]" />
+              <span v-else>Other</span>
+            </div>
+          </template>
+          <template #popper>
+            <div
+              class="py-2 text-sm text-oc-text-400 font-medium px-3 max-w-[217px]"
+            >
+              {{ legendTooltipText[item.name] }}
+            </div>
+          </template>
+        </Tooltip>
+      </div>
     </div>
+    <dummy-data v-if="dummyData" absolute>
+      <slot name="dummy-data-description">
+        Demo reports will be replaced once <br />
+        you made transactions
+      </slot>
+    </dummy-data>
   </div>
 </template>
 
 <script setup lang="ts">
 import * as echarts from "echarts";
-import { Tooltip } from "@/orchidui";
+import { DummyData, Tooltip } from "@/orchidui";
 import { computed, onMounted, ref, watch } from "vue";
 
 const props = defineProps({
@@ -47,6 +55,7 @@ const props = defineProps({
   showLegend: Boolean,
   showGrid: Boolean,
   chartData: Array,
+  dummyData: Boolean,
 });
 const legendSelected = ref({
   stack_cards: true,

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.js
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.js
@@ -1,0 +1,3 @@
+import DummyData from "./OcDummyData.vue";
+
+export { DummyData };

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
@@ -1,0 +1,32 @@
+import { DummyData } from "@/orchidui";
+
+export default {
+  component: DummyData,
+  tags: ["autodocs"],
+};
+
+export const emptyPage = {
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["small", "default", "large"],
+    },
+  },
+  args: {
+    title: undefined,
+    description: "Description",
+  },
+  render: (args) => ({
+    components: {
+      DummyData,
+    },
+    setup() {
+      return { args };
+    },
+    template: `
+          <div class="h-[300px]">
+            <DummyData v-bind="args"/>
+          </div>
+        `,
+  }),
+};

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
@@ -15,6 +15,7 @@ export const emptyPage = {
   args: {
     title: undefined,
     description: "Description",
+    absolute: false,
   },
   render: (args) => ({
     components: {
@@ -25,7 +26,7 @@ export const emptyPage = {
     },
     template: `
           <div class="h-[300px]">
-            <DummyData v-bind="args"/>
+            <DummyData v-bind="args" />
           </div>
         `,
   }),

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.stories.js
@@ -15,7 +15,7 @@ export const emptyPage = {
   args: {
     title: undefined,
     description: "Description",
-    absolute: false,
+    isAbsolute: false,
   },
   render: (args) => ({
     components: {

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
@@ -6,6 +6,10 @@ defineProps({
     type: String,
     default: "Dummy data",
   },
+  description: {
+    type: String,
+    default: "Demo reports will be replaced once you made transactions",
+  },
   absolute: {
     type: Boolean,
     default: false,
@@ -21,16 +25,15 @@ defineProps({
     <div
       class="absolute left-0 right-0 top-0 bottom-0 opacity-80 bg-white"
     ></div>
-    <Tooltip position="top" :distance="10">
+    <Tooltip
+      position="top"
+      :distance="10"
+      popper-class="min-w-[220px] bg-white"
+    >
       <Chip :label="title" variant="warning" class="cursor-default" />
       <template #popper>
-        <div
-          class="py-2 px-3 font-medium text-sm text-oc-text-400 w-max text-center"
-        >
-          <slot>
-            Demo reports will be replaced once <br />
-            you made transactions
-          </slot>
+        <div class="py-2 px-3 font-medium text-sm text-oc-text-400 text-center">
+          {{ description }}
         </div>
       </template>
     </Tooltip>

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { Chip, Tooltip } from "@/orchidui";
+
+defineProps({
+  title: {
+    type: String,
+    default: "Dummy data",
+  },
+  absolute: {
+    type: Boolean,
+    default: false,
+  },
+});
+</script>
+
+<template>
+  <div
+    class="flex flex-col justify-center items-center h-full w-full"
+    :class="{ 'absolute top-0 left-0': absolute }"
+  >
+    <div
+      class="absolute left-0 right-0 top-0 bottom-0 opacity-80 bg-white"
+    ></div>
+    <Tooltip position="top" :distance="10">
+      <Chip :label="title" variant="warning" class="cursor-default" />
+      <template #popper>
+        <div
+          class="py-2 px-3 font-medium text-sm text-oc-text-400 w-max text-center"
+        >
+          <slot>
+            Demo reports will be replaced once <br />
+            you made transactions
+          </slot>
+        </div>
+      </template>
+    </Tooltip>
+  </div>
+</template>

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { Chip, Tooltip } from "@/orchidui";
+import { ref } from "vue";
 
-defineProps({
+const props = defineProps({
   title: {
     type: String,
     default: "Dummy data",
@@ -15,12 +16,20 @@ defineProps({
     default: false,
   },
 });
+
+const hide = ref(true);
 </script>
 
 <template>
   <div
-    class="flex flex-col justify-center items-center h-full w-full"
-    :class="{ 'absolute top-0 left-0': absolute }"
+    @mouseenter="hide = false"
+    @mouseleave="hide = true"
+    class="flex flex-col justify-center items-center h-full w-full transition duration-300"
+    :class="{
+      'absolute top-0 left-0': absolute,
+      'opacity-100': !hide,
+      'opacity-0': hide,
+    }"
   >
     <div
       class="absolute left-0 right-0 top-0 bottom-0 opacity-80 bg-white"

--- a/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/DummyData/OcDummyData.vue
@@ -11,7 +11,7 @@ const props = defineProps({
     type: String,
     default: "Demo reports will be replaced once you made transactions",
   },
-  absolute: {
+  isAbsolute: {
     type: Boolean,
     default: false,
   },
@@ -26,7 +26,7 @@ const hide = ref(true);
     @mouseleave="hide = true"
     class="flex flex-col justify-center items-center h-full w-full transition duration-300"
     :class="{
-      'absolute top-0 left-0': absolute,
+      'absolute top-0 left-0': isAbsolute,
       'opacity-100': !hide,
       'opacity-0': hide,
     }"

--- a/packages/@orchidui-vue/src/index.js
+++ b/packages/@orchidui-vue/src/index.js
@@ -4,6 +4,7 @@ export * from "./DataDisplay/Overview/OcOverview.js";
 export * from "./DataDisplay/CustomerCard/OcCustomerCard.js";
 export * from "./DataDisplay/ListItem/OcListItem.js";
 export * from "./DataDisplay/InfoCard/OcInfoCard.js";
+export * from "./DataDisplay/DummyData/OcDummyData.js";
 
 export * from "./Disclosure/Accordion/OcAccordion.js";
 export * from "./Disclosure/Tabs/Tabs.js";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `DummyData` component for displaying placeholder content across various charts.
	- Added the ability to display dummy data on Bar, Bar Race, Line, and Pie Charts.

- **Enhancements**
	- Improved chart templates to conditionally render the new dummy data component.

- **Documentation**
	- Created and documented stories for the `DummyData` component in Storybook.

- **Style**
	- Adjusted styles and structural elements of chart components to accommodate the new `DummyData` feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->