### PR TITLE
ocSelect: add subLabel prop

### DIFF
--- a/packages/@orchidui-vue/src/Form/Select/OcOption.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcOption.vue
@@ -19,8 +19,8 @@ defineProps({
       :model-value="!!isSelected"
       class="!w-fit pointer-events-none"
     />
-    <div class="flex flex-col gap-3 w-[inherit]">
-      <span :class="isCheckboxes ? 'flex-1' : ''">{{ label }}</span>
+    <div class="flex flex-col gap-3" :class="{ 'flex-1': isCheckboxes }">
+      <span>{{ label }}</span>
       <span v-if="subLabel" class="text-sm text-oc-text-300">{{
         subLabel
       }}</span>

--- a/packages/@orchidui-vue/src/Form/Select/OcOption.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcOption.vue
@@ -3,6 +3,7 @@ import { Icon, Checkbox } from "@/orchidui";
 
 defineProps({
   label: String,
+  subLabel: String,
   isSelected: [Boolean, Number],
   isCheckboxes: Boolean,
 });
@@ -18,7 +19,12 @@ defineProps({
       :model-value="!!isSelected"
       class="!w-fit pointer-events-none"
     />
-    <span :class="isCheckboxes ? 'flex-1' : ''">{{ label }}</span>
+    <div class="flex flex-col gap-3 w-[inherit]">
+      <span :class="isCheckboxes ? 'flex-1' : ''">{{ label }}</span>
+      <span v-if="subLabel" class="text-sm text-oc-text-300">{{
+        subLabel
+      }}</span>
+    </div>
     <Icon
       v-if="isSelected && !isCheckboxes"
       class="w-5 h-5 text-oc-primary"

--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.stories.js
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.stories.js
@@ -22,10 +22,12 @@ export const Default = {
     options: [
       {
         label: "Option 1",
+        subLabel: "sub label of Option 1",
         value: 1,
       },
       {
         label: "Option 2",
+        subLabel: "sub label of Option 2",
         value: 2,
       },
       {

--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -234,6 +234,7 @@ const selectAll = () => {
                 v-for="option in filterableOptions"
                 :key="option.value"
                 :label="option.label"
+                :sub-label="option.subLabel"
                 :is-checkboxes="isCheckboxes"
                 :is-selected="
                   multiple


### PR DESCRIPTION
![image](https://github.com/hit-pay/orchid/assets/47066872/250ffb87-4bbf-4e2a-a881-1e497b21faae)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `subLabel` property for options in select components to display additional information below the main label.

- **Enhancements**
	- Updated the select component UI to support a flex column layout when `subLabel` is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->