### PR TITLE
[Chore] DataTable: Adding custom per page options

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,13 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies  build and publish 🔧
-        run: npm ci && npm run publish
+      - name: Install dependencies  build and publish orchid ui vue🔧
+        run: npm ci 
+        run: git config --global user.name 'Automated publish'
+        run: git config --global user.email 'orchidui@hitpayapp.com'
+        run: npm install --prefix packages/@orchidui-vue
+        run: npm run build --prefix packages/@orchidui-vue
+        run: npm version patch --prefix packages/@orchidui-vue
+      - run: npm publish --prefix packages/@orchidui-vue
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.vue
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.vue
@@ -78,8 +78,15 @@ const defaultQuery =
 const queries = ref(defaultQuery ? defaultQuery.split(",") : []);
 const isSearchExpanded = ref(false);
 
+const customPerPageOptions = computed(() => {
+  return props.options?.perPageOptions?.map(perPage => ({
+    label: `${perPage}`,
+    value: perPage,
+  })) ?? null;
+})
+
 const perPageOptions = computed(() => {
-  let per_page_option = [
+  let default_per_page_option = [
     {
       label: "10",
       value: 10,
@@ -113,12 +120,12 @@ const perPageOptions = computed(() => {
       value: 99,
     },
   ];
-  let opt = per_page_option;
+  let opt = customPerPageOptions.value ?? default_per_page_option;
   if (paginationOption.value) {
     const maxLength =
       paginationOption.value.total < 100 ? paginationOption.value.total : 100;
     if (maxLength > 10) {
-      opt = per_page_option.filter((p) => {
+      opt = opt.filter((p) => {
         return p.value <= maxLength;
       });
     }

--- a/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
+++ b/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
@@ -9,6 +9,7 @@ const DataTableOptions = {
   //   prev: "prev_cursor_key",
   //   next: "next_cursor_key",
   // },
+  perPageOptions: [10,25,50,100],
   filterOptions: {
     per_page: {
       key: "per_page",

--- a/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
+++ b/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
@@ -9,7 +9,7 @@ const DataTableOptions = {
   //   prev: "prev_cursor_key",
   //   next: "next_cursor_key",
   // },
-  perPageOptions: [10,25,50,100],
+  // perPageOptions: [10,25,50,100],
   filterOptions: {
     per_page: {
       key: "per_page",


### PR DESCRIPTION
Addding `option.perPageOptions`  prop for set custom per page options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Updated the data table to use custom options for items displayed per page, if provided.

- **New Features**
  - Introduced configurable options for the number of items to display per page in the data table settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->