### PR TITLE
Added canny-badge class to drop-down-item

### DIFF
--- a/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
+++ b/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
@@ -59,7 +59,6 @@ const onClickOutside = () => {
             v-show="modelValue"
             :class="menuClasses"
             class="rounded bg-oc-bg-light shadow min-w-[162px]"
-            @click.stop
           >
             <slot name="menu" />
           </div>

--- a/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdownItem.vue
+++ b/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdownItem.vue
@@ -36,9 +36,9 @@ const variantClasses = computed(() => ({
 
       <span>{{ text }}</span>
 
-      <div v-if="pointed" class="Canny_BadgeContainer">
-        <div class="Canny_Badge" />
-      </div>
+      <slot v-if="pointed" name="badge">
+        <div class="w-[6px] aspect-square rounded-full bg-oc-error" />
+      </slot>
     </div>
 
     <div v-if="subText" class="p-3 text-sm text-oc-text-300">
@@ -46,11 +46,3 @@ const variantClasses = computed(() => ({
     </div>
   </div>
 </template>
-<style scoped lang="scss">
-.Canny_BadgeContainer {
-  @apply static flex items-center justify-center;
-  .Canny_Badge {
-    @apply p-[3px] aspect-square static rounded-full bg-[var(--oc-error-500)];
-  }
-}
-</style>

--- a/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdownItem.vue
+++ b/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdownItem.vue
@@ -36,10 +36,9 @@ const variantClasses = computed(() => ({
 
       <span>{{ text }}</span>
 
-      <div
-        v-if="pointed"
-        class="w-[6px] aspect-square rounded-full bg-oc-error"
-      />
+      <div v-if="pointed" class="Canny_BadgeContainer">
+        <div class="Canny_Badge" />
+      </div>
     </div>
 
     <div v-if="subText" class="p-3 text-sm text-oc-text-300">
@@ -47,3 +46,11 @@ const variantClasses = computed(() => ({
     </div>
   </div>
 </template>
+<style scoped lang="scss">
+.Canny_BadgeContainer {
+  @apply static flex items-center justify-center;
+  .Canny_Badge {
+    @apply p-[3px] aspect-square static rounded-full bg-[var(--oc-error-500)];
+  }
+}
+</style>

--- a/packages/@orchidui-vue/src/Overlay/SupportMenu/OcSupportMenu.vue
+++ b/packages/@orchidui-vue/src/Overlay/SupportMenu/OcSupportMenu.vue
@@ -111,7 +111,11 @@ onMounted(() => {
               :key="i"
               class="text-sm"
               v-bind="item"
-            />
+            >
+              <template #badge>
+                <slot name="badge" />
+              </template>
+            </DropdownItem>
           </template>
 
           <div class="w-full border-t border-gray-200" />


### PR DESCRIPTION
By default there still will be red point (without canny)
Canny logic using here only for show or hide point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved click event handling within dropdown menus for better user interaction.
  
- **New Features**
  - Introduced a badge feature in dropdown items for enhanced visual cues.

- **Style**
  - Implemented scoped CSS for the new badge feature to ensure consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->