### PR TITLE
chore/SingleFileInput: Adding upload button custom props

### DIFF
--- a/packages/@orchidui-vue/src/Form/SingleFileUpload/OcSingleFileUpload.vue
+++ b/packages/@orchidui-vue/src/Form/SingleFileUpload/OcSingleFileUpload.vue
@@ -18,6 +18,7 @@ const props = defineProps({
   imageClasses: String,
   label: String,
   hint: String,
+  uploadButtonOptions: Object,
   /**
    * Variant of input (upload or url)
    */
@@ -149,9 +150,9 @@ const onEditFile = () => {
             </span>
             <Button
               size="small"
-              variant="secondary"
-              left-icon="upload"
-              label="Upload"
+              :variant="uploadButtonOptions?.variant ?? 'secondary'"
+              :left-icon="uploadButtonOptions?.leftIcon ?? 'upload'"
+              :label="uploadButtonOptions?.label ?? 'Upload'"
               @click="inputRef.click()"
             />
           </div>


### PR DESCRIPTION
Added custom variant, left icon and label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced customizable `uploadButtonOptions` for the Single File Upload feature, allowing users to personalize the upload button's appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->