### PR TITLE
fix/avoid overlapping elements

### DIFF
--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
@@ -159,7 +159,7 @@ onMounted(() => onScroll());
       <div
         v-for="i in loadingRows"
         :key="i"
-        class="flex flex-wrap md:flex-nowrap relative group/row border-oc-gray-200 md:p-0 py-3"
+        class="flex flex-wrap md:flex-nowrap group/row border-oc-gray-200 md:p-0 py-3"
         :class="{
           'pl-[40px]': isSelectable,
         }"
@@ -182,7 +182,7 @@ onMounted(() => onScroll());
       <div
         v-for="(field, i) in fields"
         :key="i"
-        class="flex relative group/row md:p-0 py-3"
+        class="flex group/row md:p-0 py-3"
         :class="[
           {
             'border-b md:border-b-0': fields.length !== i + 1,

--- a/packages/@orchidui-vue/src/Disclosure/Accordion/OcAccordion.vue
+++ b/packages/@orchidui-vue/src/Disclosure/Accordion/OcAccordion.vue
@@ -66,7 +66,7 @@ onUpdated(() => {
   <div :class="isDisabled && 'opacity-60'">
     <div>
       <div
-        class="border-oc-accent-1-50 py-3 text-sm border relative z-10 justify-between px-4 gap-x-3 flex hover:border-oc-gray-200 items-center w-full text-oc-text"
+        class="border-oc-accent-1-50 py-3 text-sm border z-10 justify-between px-4 gap-x-3 flex hover:border-oc-gray-200 items-center w-full text-oc-text"
         :class="[
           isExpandable
             ? 'rounded-t border-oc-gray-200'
@@ -100,7 +100,7 @@ onUpdated(() => {
         ]"
       >
         <div
-          class="text-oc-text text-sm p-4 rounded-b relative z-0 border-x border-b"
+          class="text-oc-text text-sm p-4 rounded-b z-0 border-x border-b"
           :class="[
             isExpandable ? 'border-oc-gray-200' : ' border-transparent',
             bodyStyle,

--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -174,7 +174,6 @@ const selectAll = () => {
   <BaseInput
     :label="isInlineLabel ? '' : label"
     :hint="hint"
-    class="relative"
     :error-message="errorMessage"
     :is-required="isRequired"
     :label-icon="labelIcon"


### PR DESCRIPTION
relative class is making some element to be overlapped (as you can see .Removing relative classes

|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/91492e45-ef54-4917-8ebd-e2b36a9a715b)|![image](https://github.com/hit-pay/orchid/assets/4713316/3bd8b3fc-ffa5-4ff7-93e7-2c988b45302d)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Updates**
	- Enhanced table visuals by conditionally applying padding and border styles.
	- Simplified accordion styling by removing hover and positioning classes.
	- Updated select input design by altering layout-related classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->