### PR TITLE
[Chore] Emit event when click row item

### DIFF
--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
@@ -87,6 +87,7 @@ const variantClass = computed(() => ({
       v-else
       class="w-full flex"
       :class="isCopy ? 'justify-between' : 'justify-start'"
+      @click="$emit('click:field')"
     >
       <slot>
         <!--  CHECKBOX    -->

--- a/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
+++ b/packages/@orchidui-vue/src/Overlay/CopyTooltip/OcCopyTooltip.vue
@@ -41,7 +41,7 @@ const copyToClipboard = async (data) => {
       </div>
     </template>
     <template #default="{ isShow }">
-      <div @click="copyToClipboard(value)">
+      <div @click.stop="copyToClipboard(value)">
         <slot :is-show="isShow">
           <Icon
             width="14"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Table cells now emit a 'click:field' event when clicked, allowing for interactive data display.
  
- **Enhancements**
	- Improved user experience by preventing event propagation when using the copy tooltip feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->