### PR TITLE
Update snackbar to render html blocks in content

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.3.91",
+  "version": "0.3.93",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Disclosure/Tabs/OcTabs.vue
+++ b/packages/@orchidui-vue/src/Disclosure/Tabs/OcTabs.vue
@@ -8,7 +8,7 @@ const props = defineProps({
     validator: (val) => ["default", "pills"].includes(val),
   },
   tabs: Array,
-  modelValue: String,
+  modelValue: [String, Array],
   maxCount: Number,
 });
 defineEmits({

--- a/packages/@orchidui-vue/src/Feedback/Snackbar/OcSnackbar.vue
+++ b/packages/@orchidui-vue/src/Feedback/Snackbar/OcSnackbar.vue
@@ -31,6 +31,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  isRawHtml: {
+    type: Boolean,
+    default: false,
+  },
   position: {
     type: String,
     default: "top-center",
@@ -89,9 +93,10 @@ watch(
       <Icon v-if="showIcon" :name="icon" class="shrink-0" />
       <slot>
         <div class="w-full flex items-center justify-between">
-          <span class="text-oc-text text-sm">
+          <span v-if="!isRawHtml" class="text-oc-text text-sm">
             {{ content }}
           </span>
+          <span v-else class="text-oc-text text-sm" v-html="content" />
           <div
             v-if="isCloseIcon"
             class="rounded cursor-pointer text-oc-gray-500 hover:bg-transparent hover:text-oc-text"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Snackbar now supports rendering content as plain text or raw HTML, controlled by a new `isRawHtml` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->