### PR TITLE
Fixed select overflow cutting

### DIFF
--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -8,7 +8,7 @@ import {
   Button,
   Dropdown,
 } from "@/orchidui";
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 const props = defineProps({
   label: String,
@@ -52,6 +52,10 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  popperOptions: {
+    type: Object,
+    default: () => ({}),
+  },
 });
 
 const emit = defineEmits({
@@ -74,7 +78,7 @@ const isSelectedAll = computed(() => {
 });
 
 const filterableOptions = computed(
-  () => filterOptions(props.options, query.value) || []
+  () => filterOptions(props.options, query.value) || [],
 );
 
 const localValueOption = computed(() => {
@@ -105,7 +109,7 @@ const filterOptions = (options, query) => {
   for (const option of options) {
     if (option.values) {
       const filteredGroup = option.values.filter((subOption) =>
-        subOption.label.toLowerCase().includes(query.toLowerCase())
+        subOption.label.toLowerCase().includes(query.toLowerCase()),
       );
 
       if (filteredGroup.length > 0) {
@@ -128,7 +132,7 @@ const selectOption = (option) => {
 
   if (props.multiple) {
     const isOptionHasBeenSelected = (props.modelValue || []).find(
-      (o) => o === option.value
+      (o) => o === option.value,
     );
 
     if (
@@ -155,7 +159,7 @@ const selectOption = (option) => {
 const removeOption = (value) => {
   emit(
     "update:modelValue",
-    (props.modelValue || []).filter((o) => o !== value)
+    (props.modelValue || []).filter((o) => o !== value),
   );
 };
 const selectAll = () => {
@@ -164,14 +168,20 @@ const selectAll = () => {
   } else {
     emit(
       "update:modelValue",
-      filterableOptions.value.map((o) => o.value)
+      filterableOptions.value.map((o) => o.value),
     );
   }
 };
+const baseInput = ref();
+const maxPopperWidth = ref(0);
+onMounted(() => {
+  maxPopperWidth.value = baseInput.value.$el.offsetWidth;
+});
 </script>
 
 <template>
   <BaseInput
+    ref="baseInput"
     class="relative"
     :label="isInlineLabel ? '' : label"
     :hint="hint"
@@ -186,6 +196,9 @@ const selectAll = () => {
       class="w-full"
       :distance="4"
       popper-class="w-full"
+      placement="bottom-end"
+      :popper-style="{ maxWidth: `${maxPopperWidth}px` }"
+      :popper-options="popperOptions"
       :is-disabled="isDisabled"
     >
       <div

--- a/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
+++ b/packages/@orchidui-vue/src/Overlay/Dropdown/OcDropdown.vue
@@ -23,6 +23,7 @@ const props = defineProps({
     default: "bottom-start",
   },
   popperOptions: Object,
+  popperStyle: Object,
   popperClass: [String, Array, Object],
   modelValue: Boolean,
   preventClickOutside: Boolean,
@@ -48,9 +49,10 @@ const onClickOutside = () => {
       :distance="distance"
       :popper-class="popperClass"
       :skidding="skidding"
+      :popper-style="popperStyle"
       :popper-options="popperOptions"
     >
-      <div class="w-[inherit] flex" @click.stop="toggleDropdown">
+      <div class="w-[inherit] flex" @click="toggleDropdown">
         <slot />
       </div>
       <template #popper>

--- a/packages/@orchidui-vue/src/Overlay/Popper/OcPopper.vue
+++ b/packages/@orchidui-vue/src/Overlay/Popper/OcPopper.vue
@@ -19,6 +19,9 @@ const props = defineProps({
   popperOptions: {
     type: Object,
   },
+  popperStyle: {
+    type: Object,
+  },
   skidding: {
     type: Number,
     default: 0,
@@ -79,7 +82,12 @@ watch(
     <div ref="reference" class="w-[inherit] flex">
       <slot />
     </div>
-    <div ref="popper" :class="popperClass" class="z-[1005]">
+    <div
+      ref="popper"
+      :class="popperClass"
+      :style="popperStyle"
+      class="z-[1005]"
+    >
       <slot name="popper" />
     </div>
   </div>


### PR DESCRIPTION
Calculated maxWidth for popper of parent element in OcSelect and chan ged strategy to fixed to prevent cutting popper by overflow hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `popperStyle` prop to customize the style of popper elements in dropdowns and selects.

- **Enhancements**
	- Improved default popper behavior by setting a maximum width based on the triggering element.
	- Enhanced select component with better initialization for popper positioning options.

- **Refactor**
	- Updated select and popper components with modern syntax and improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->