### PR TITLE
chore/OcModal: Removing @click.stop event and modifier

### DIFF
--- a/packages/@orchidui-vue/src/Overlay/Modal/OcModal.vue
+++ b/packages/@orchidui-vue/src/Overlay/Modal/OcModal.vue
@@ -100,7 +100,6 @@ const sizeClasses = computed(() => ({
     <div
       class="shadow-normal w-[calc(100%-40px)] bg-oc-bg-light rounded-xl flex flex-col max-h-screen overflow-y-auto"
       :class="sizeClasses[size]"
-      @click.stop
     >
       <div
         class="flex border-oc-gray-200 gap-x-9 justify-between p-5 items-start"


### PR DESCRIPTION
Removing unnecessary event and modifier. This is avoiding `OcSelect` to dismiss dropdown by clicking outside when it's inside a `OcModal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved event handling in the modal component by refining click event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->