### PR TITLE
ocTimePicker: Edit modelValue watcher with fallback value

### DIFF
--- a/packages/@orchidui-vue/src/Form/TimePicker/OcTimePicker.vue
+++ b/packages/@orchidui-vue/src/Form/TimePicker/OcTimePicker.vue
@@ -49,7 +49,7 @@ const updateActiveTime = () => {
 watch(
   () => props.modelValue,
   (value) => {
-    time.value = value;
+    time.value = value != "" ? value : dayjs().toDate();
   },
   { immediate: true },
 );


### PR DESCRIPTION
modelValue of ocTimePicker component cannot be an empty string! It will cause errors when calling `getHours()` method.
This bug accurs when using ocFormBuilder.
![image](https://github.com/hit-pay/orchid/assets/47066872/0e717713-7cb1-4945-8e73-9a2746b25372)
![image](https://github.com/hit-pay/orchid/assets/47066872/b057e1f8-dd04-4991-992a-b61b373f923e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - TimePicker now correctly sets the time based on the provided model value or defaults to the current date when no value is given.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->