### PR TITLE
Add slot to tooltip in dynamic content

### DIFF
--- a/packages/@orchidui-vue/src/Elements/AdditionalContent/DynamicType/OcDynamicType.vue
+++ b/packages/@orchidui-vue/src/Elements/AdditionalContent/DynamicType/OcDynamicType.vue
@@ -47,7 +47,9 @@ defineEmits(["addCustomer"]);
             name="information"
           />
           <template #popper>
-            <div class="py-2 px-3">{{ box.infoTooltip }}</div>
+            <slot :name="box.infoTooltipSlot">
+              <div class="py-2 px-3">{{ box.infoTooltip }}</div>
+            </slot>
           </template>
         </Tooltip>
       </div>

--- a/packages/@orchidui-vue/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
+++ b/packages/@orchidui-vue/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
@@ -60,6 +60,7 @@ const argTypes = {
           showInfo: true,
           infoTooltip: "Tooltip",
           infoTooltipStyle: "absolute right-3",
+          infoTooltipSlot: "BoxInfoTooltip",
           style: "!grid-cols-2 relative pr-10",
           slot: "Box",
           items: [
@@ -272,6 +273,11 @@ export const Dynamic = {
                     <div class="text-oc-success-500">{{field.content}}</div>
                   </template>
                 </OverviewItem>
+              </template>
+              <template #BoxInfoTooltip>
+                <div class="p-4">
+                  <div class="text-oc-error">Tooltip</div>
+                </div>
               </template>
             </AdditionalContent>
           </Theme>

--- a/packages/@orchidui-vue/src/Elements/AdditionalContent/OcAdditionalContent.vue
+++ b/packages/@orchidui-vue/src/Elements/AdditionalContent/OcAdditionalContent.vue
@@ -78,6 +78,10 @@ const copyLink = async () => {
       <template v-for="box in boxes" v-slot:[box.slot]="{ data }">
         <slot :name="box.slot" :data="data"></slot>
       </template>
+
+      <template v-for="box in boxes" v-slot:[box.infoTooltipSlot]="{ data }">
+        <slot :name="box.infoTooltipSlot" :data="data"></slot>
+      </template>
     </DynamicType>
 
     <BalanceOverview


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new slot for tooltips within the `DynamicType` component, allowing for more customizable content.
	- Enhanced the `AdditionalContent` component to support multiple boxes and a new tooltip slot for dynamic content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->