### PR TITLE
ocTableCell: Add new prop addDescriptionToCopyClipboard (Related to ocDataTable)

### DIFF
--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
@@ -244,6 +244,9 @@ onMounted(() => onScroll());
             :is-last="fields.length === i + 1"
             :variant="header.variant"
             :is-copy="header.isCopy"
+            :add-description-to-copy-clipboard="
+              header.addDescriptionToCopyClipboard ?? true
+            "
             :data="field[`${header.key}`] ?? ''"
             :content="{
               important: header.important ?? false,

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
@@ -27,6 +27,7 @@ const props = defineProps({
   },
   isLast: Boolean,
   isCopy: Boolean,
+  addDescriptionToCopyClipboard: Boolean,
   isSelected: Boolean,
   data: [String, Number, Object, Array, Boolean],
   isLoading: Boolean,
@@ -166,7 +167,9 @@ const variantClass = computed(() => ({
         :value="
           content?.title
             ? `${content.title}${
-                content.description ? `,${content.description}` : ''
+                content.description && props.addDescriptionToCopyClipboard
+                  ? `,${content.description}`
+                  : ''
               }`
             : data
         "

--- a/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
+++ b/packages/@orchidui-vue/src/data/DataTableOptions.sample.js
@@ -61,6 +61,7 @@ const DataTableOptions = {
         href: "col3Url",
         description: "col3Description",
         isCopy: true,
+        addDescriptionToCopyClipboard: true,
         class: "w-1/2 md:w-[12%]",
       },
       {


### PR DESCRIPTION
Add flexibility to "Copy" button on a table row.

- addDescriptionToCopyClipboard = true: copy to clipboard "title, description"
- addDescriptionToCopyClipboard = false: "title"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Table component to optionally include descriptions when copying content to the clipboard, improving data context for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->