### PR TITLE
[Chore] OcInput:Leading

### DIFF
--- a/packages/@orchidui-vue/src/Form/Input/OcInput.stories.js
+++ b/packages/@orchidui-vue/src/Form/Input/OcInput.stories.js
@@ -224,6 +224,35 @@ export const Trailing = {
   }),
 };
 
+export const After = {
+  render: () => ({
+    components: { Theme, OCInput, Icon },
+    setup() {
+      const modelValue = ref('');
+
+      return {
+        modelValue,
+      };
+    },
+    template: `
+      <Theme colorMode="light" class="py-4">
+        <OCInput
+          v-model="modelValue"
+          label="Password"
+          input-type="password"
+          :has-leading-separator="false"
+        >
+          <template #leading>
+            <span class="text-oc-text-200">
+              <Icon name="eye-open" width="16" height="16" />
+            </span>
+          </template>
+        </OCInput>
+      </Theme>
+    `,
+  }),
+}
+
 export const Leading = {
   render: () => ({
     components: { Theme, OCInput, Dropdown, DropdownItem, Icon, BaseInput },

--- a/packages/@orchidui-vue/src/Form/Input/OcInput.vue
+++ b/packages/@orchidui-vue/src/Form/Input/OcInput.vue
@@ -72,6 +72,10 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  hasLeadingSeparator: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits(["update:modelValue", "blur", "focus"]);
@@ -156,7 +160,12 @@ const inputClasses = computed(() => [
         </div>
       </div>
 
-      <div v-if="$slots.leading" class="border-l border-gray-200 pl-3 py-3">
+      <div
+        v-if="$slots.leading"
+        :class="{
+          'border-l border-gray-200 pl-3 py-3': hasLeadingSeparator
+        }"
+      >
         <slot name="leading" />
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new demonstrative story for the `OCInput` component showcasing a password field with a leading icon.
	- Added a `hasLeadingSeparator` property to the `OCInput` component, enabling users to control the display of a leading separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->