### PR TITLE
Added option to reformat min value when max is lower and opposite

### DIFF
--- a/packages/@orchidui-vue/src/Form/RangeInput/OcRangeInput.vue
+++ b/packages/@orchidui-vue/src/Form/RangeInput/OcRangeInput.vue
@@ -51,6 +51,12 @@ const updateRange = (value, index) => {
     if (!props.onlyInput) {
       slider.value.updateSlider([localMinValue.value, localMaxValue.value]);
     } else {
+      if (localMinValue.value > localMaxValue.value) {
+        localMaxValue.value = localMinValue.value;
+      }
+      if (localMaxValue.value < localMinValue.value) {
+        localMinValue.value = localMaxValue.value;
+      }
       emit("update:modelValue", [localMinValue.value, localMaxValue.value]);
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the `OcRangeInput` component to ensure the minimum value cannot exceed the maximum value and vice versa, maintaining consistent range input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->