### PR TITLE
TailwindCSS: Enable hoverOnlyWhenSupported flag

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -180,4 +180,7 @@ module.exports = {
       },
     },
   },
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
 };


### PR DESCRIPTION
- To solve mobile issues related to sticky hover effect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to enable hover styles only on devices that support hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->