### PR TITLE
Added persistent in confirm modal

### DIFF
--- a/packages/@orchidui-vue/package-lock.json
+++ b/packages/@orchidui-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.4.153",
+  "version": "0.4.155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.4.153",
+      "version": "0.4.155",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.3",

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.154",
+  "version": "0.4.155",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/Overlay/ConfirmationModal/OcConfirmationModal.vue
+++ b/packages/@orchidui-vue/src/Overlay/ConfirmationModal/OcConfirmationModal.vue
@@ -35,6 +35,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  persistent: {
+    type: Boolean,
+    default: false,
+  },
   contentClass: String,
 });
 const emit = defineEmits(["confirm", "cancel", "update:model-value"]);
@@ -80,6 +84,7 @@ const emitModelValue = (e) => {
     :model-value="modelValue"
     :title="title"
     is-borderless
+    :persistent="persistent"
     :cancel-button-props="
       labelCancel
         ? {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `persistent` option to the Confirmation Modal, allowing it to remain open until explicitly closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->