### PR TITLE
fix/OcDataTable row action dropdown is below pagination size dropdown

### DIFF
--- a/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
+++ b/packages/@orchidui-vue/src/Builder/DataTable/OcDataTable.stories.js
@@ -7,6 +7,8 @@ import {
   Toggle,
   TableCellContent,
   Button,
+  Dropdown,
+  DropdownItem,
 } from "@/orchidui";
 
 import { ref } from "vue";
@@ -33,11 +35,14 @@ export const Default = {
       Chip,
       TableCellContent,
       Button,
+      Dropdown,
+      DropdownItem,
     },
     setup() {
       const filter = ref(Filter);
       const changedFields = ref([]);
       const selectedRows = ref([]);
+      const showDropdown = ref({})
       const updateFilterData = (data) => {
         filter.value = data;
       };
@@ -45,11 +50,21 @@ export const Default = {
         console.log("onClickRow  ", val);
       };
 
+      const handleOpenDropdown = (itemId) => {
+        Object.keys(showDropdown.value).forEach((id) => {
+          if (id !== itemId) {
+            showDropdown.value[id] = false
+          }
+        })
+      }
+
       return {
         args,
         filter,
         changedFields,
         selectedRows,
+        showDropdown,
+        handleOpenDropdown,
         updateFilterData,
         onClickRow,
       };
@@ -118,8 +133,41 @@ export const Default = {
                   </span>
                 </div>
               </template>
-              <template #actions>
-                <Icon class="w-6 h-6 group-hover/row:block md:hidden cursor-pointer mx-auto" name="dots-vertical"/>
+              <template #actions="{ item }">
+                <Dropdown
+                  v-model="showDropdown[item.id]"
+                  :distance="10"
+                  @update:modelValue="handleOpenDropdown(item.id)"
+                >
+                  <Icon class="w-6 h-6 group-hover/row:block md:hidden cursor-pointer mx-auto" name="dots-vertical"/>
+
+
+                  <template #menu>
+                    <div class="flex flex-col">
+                      <div class="p-2 border-b border-gray-200">
+                        <DropdownItem
+                          text="Copy Link"
+                          icon="copy"
+                        />
+                        <DropdownItem
+                        text="Resend e-mail"
+                          icon="telegram"
+                        />
+                        <DropdownItem
+                          text="Download PDF"
+                          icon="download"
+                        />
+                      </div>
+                      <div class="p-2">
+                        <DropdownItem
+                          text="Delete"
+                          icon="bin"
+                          variant="destructive"
+                        />
+                      </div>
+                    </div>
+                  </template>
+                </Dropdown>
               </template>
               <template #after>
                 Slot After

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTable.vue
@@ -114,7 +114,7 @@ onMounted(() => onScroll());
 <template>
   <div
     ref="scrollTable"
-    class="flex text-oc-text flex-col border border-oc-gray-200 isolate"
+    class="flex text-oc-text flex-col border border-oc-gray-200 isolate z-10"
     :class="[
       isSticky ? 'overflow-x-auto' : 'overflow-hidden',
       isResponsive ? 'rounded' : 'md:rounded',


### PR DESCRIPTION
- Adding z-index to table container
- Add dropdown to OcDataTable story

|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/f6a0c1f9-a2c1-4458-b079-c5bf92f94013)|![image](https://github.com/hit-pay/orchid/assets/4713316/fb355751-1714-4ed8-8617-215c0b54ace2)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated a dropdown menu for actions in DataTable stories.
	- Enhanced table display with improved layering through z-index adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->