### PR TITLE
ocTableCell: CSS Fix default variant padding on mobile (orc-HIT-5766)

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.157",
+  "version": "0.4.158",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
@@ -71,7 +71,10 @@ const variantClass = computed(() => ({
 
 <template>
   <div
-    :class="[variantClass[variant], isLoading ? 'flex items-center' : '']"
+    :class="[
+      variantClass[variant] ?? 'px-4',
+      isLoading ? 'flex items-center' : '',
+    ]"
     class="md:py-3 md:px-4 px-3 py-1 bg-oc-bg-light md:min-h-[58px] md:group-hover/row:bg-oc-gray-50 items-center"
   >
     <div

--- a/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Table/OcTableCell.vue
@@ -18,12 +18,13 @@ const Variants = {
   ICON: "icon",
   IMAGE: "image",
   EMPTY: "empty",
+  DEFAULT: "default",
 };
 const props = defineProps({
   isSimple: Boolean,
   variant: {
     type: String,
-    default: "",
+    default: "default",
   },
   isLast: Boolean,
   isCopy: Boolean,
@@ -66,15 +67,13 @@ const variantClass = computed(() => ({
   [Variants.CHIP]: "px-4",
   [Variants.DATETIME]: "px-4",
   [Variants.EMPTY]: "px-4 min-w-[48px]",
+  [Variants.DEFAULT]: "px-4",
 }));
 </script>
 
 <template>
   <div
-    :class="[
-      variantClass[variant] ?? 'px-4',
-      isLoading ? 'flex items-center' : '',
-    ]"
+    :class="[variantClass[variant], isLoading ? 'flex items-center' : '']"
     class="md:py-3 md:px-4 px-3 py-1 bg-oc-bg-light md:min-h-[58px] md:group-hover/row:bg-oc-gray-50 items-center"
   >
     <div
@@ -164,7 +163,7 @@ const variantClass = computed(() => ({
 
         <!--  DEFAULT    -->
         <TableLink
-          v-else-if="data"
+          v-else-if="variant === Variants.DEFAULT"
           :link="link"
           class="flex items-center w-full"
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the handling of class bindings for table cells, enhancing the visual consistency during loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->