### PR TITLE
Add image size to terminal type

### DIFF
--- a/packages/@orchidui-vue/package-lock.json
+++ b/packages/@orchidui-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.4.161",
+  "version": "0.4.180",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.4.161",
+      "version": "0.4.180",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.3",

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.161",
+  "version": "0.4.180",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/OcListItem.stories.js
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/OcListItem.stories.js
@@ -22,6 +22,10 @@ export const listItem = {
         max: 5,
       },
     },
+    imageSize: {
+      control: "select",
+      options: ["small", "default", "big"],
+    },
   },
   args: {
     active: 1,
@@ -31,6 +35,9 @@ export const listItem = {
     iconText: "SGD 130,11",
     description: "#9a2804fc-74df-4304-a7d7-79d11f9e1db8dsdss",
     type: "timeline",
+    image:
+      "https://hitpay-staging-public.s3.ap-southeast-1.amazonaws.com/covers/small/99d696e564ba45fbaa0fb2e3b43d0e27.jpg",
+    imageSize: "small",
   },
   render: (args) => ({
     components: { Theme, ListItem },
@@ -45,7 +52,8 @@ export const listItem = {
                 :key="i"
                 :type="args.type"
                 :title="args.title"
-                image="https://hitpay-staging-public.s3.ap-southeast-1.amazonaws.com/covers/small/99d696e564ba45fbaa0fb2e3b43d0e27.jpg"
+                :image="args.image"
+                :image-size="args.imageSize"
                 :icon="args.icon"
                 :icon-class="args.iconClass"
                 :icon-text="args.iconText"

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/OcListItem.stories.js
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/OcListItem.stories.js
@@ -13,7 +13,7 @@ export const listItem = {
     },
     type: {
       control: "select",
-      options: ["timeline", "webhook", "payment"],
+      options: ["timeline", "webhook", "payment", "terminal"],
     },
     active: {
       control: {
@@ -43,7 +43,9 @@ export const listItem = {
                 v-for="i in 5"
                 :is-active="args.active >= i"
                 :key="i"
+                :type="args.type"
                 :title="args.title"
+                image="https://hitpay-staging-public.s3.ap-southeast-1.amazonaws.com/covers/small/99d696e564ba45fbaa0fb2e3b43d0e27.jpg"
                 :icon="args.icon"
                 :icon-class="args.iconClass"
                 :icon-text="args.iconText"

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
@@ -6,7 +6,7 @@ defineProps({
   image: String,
   imageSize: {
     type: String,
-    default: "default",
+    default: "medium",
   },
   description: String,
   chips: {
@@ -22,8 +22,8 @@ defineProps({
 
 const imageSizes = {
   small: "w-10",
-  default: "w-[56px]",
-  big: "w-16",
+  medium: "w-[56px]",
+  large: "w-16",
 };
 </script>
 

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
@@ -4,6 +4,10 @@ import { Chip, Button } from "@/orchidui";
 defineProps({
   title: String,
   image: String,
+  imageSize: {
+    type: Number,
+    default: 56,
+  },
   description: String,
   chips: {
     type: Array,
@@ -22,8 +26,11 @@ defineProps({
     class="p-4 flex gap-x-4 rounded items-center border border-gray-200 group"
     :class="{ 'hover:shadow-normal': !isDisabled }"
   >
-    <div class="w-[56px] shrink-0 aspect-square bg-oc-bg-dark rounded">
-      <img :src="image" alt="terminal" />
+    <div
+      class="shrink-0 aspect-square bg-oc-bg-dark rounded overflow-hidden"
+      :class="`w-[${imageSize}px]`"
+    >
+      <img :src="image" alt="terminal" class="object-contain h-full w-full" />
     </div>
 
     <div class="flex flex-col gap-y-1 overflow-hidden">

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTerminal.vue
@@ -5,8 +5,8 @@ defineProps({
   title: String,
   image: String,
   imageSize: {
-    type: Number,
-    default: 56,
+    type: String,
+    default: "default",
   },
   description: String,
   chips: {
@@ -19,6 +19,12 @@ defineProps({
   },
   isDisabled: Boolean,
 });
+
+const imageSizes = {
+  small: "w-10",
+  default: "w-[56px]",
+  big: "w-16",
+};
 </script>
 
 <template>
@@ -28,7 +34,7 @@ defineProps({
   >
     <div
       class="shrink-0 aspect-square bg-oc-bg-dark rounded overflow-hidden"
-      :class="`w-[${imageSize}px]`"
+      :class="imageSizes[imageSize]"
     >
       <img :src="image" alt="terminal" class="object-contain h-full w-full" />
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "terminal" option for list items, allowing for the inclusion of images with customizable sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->