### PR TITLE
fix/adjust-listitem

### DIFF
--- a/packages/@orchidui-vue/package-lock.json
+++ b/packages/@orchidui-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.4.186",
+  "version": "0.4.187",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.4.186",
+      "version": "0.4.187",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.3",

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.187",
+  "version": "0.4.188",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.186",
+  "version": "0.4.187",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTimeLine.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/ListItem/components/OcTimeLine.vue
@@ -43,9 +43,9 @@ defineProps({
 
       <div class="flex items-end gap-x-2">
         <Icon v-if="icon" :name="icon" :class="iconClass" />
-        <span class="text-lg font-medium" :class="iconTextClass">{{
-          iconText
-        }}</span>
+        <span class="text-lg font-medium" :class="iconTextClass">
+            <slot name="iconText">{{ iconText }} </slot>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
allow icontext to be a slot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced customization in the `OcTimeLine` component by introducing a slot for `iconText`, allowing for more flexible content rendering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->