### PR TITLE
Orc hit 6067 overview icon height width props

### DIFF
--- a/packages/@orchidui-vue/package.json
+++ b/packages/@orchidui-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.4.200",
+  "version": "0.4.201",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverviewIcon.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverviewIcon.vue
@@ -11,6 +11,14 @@ defineProps({
     type: String,
     default: "blue",
   },
+  width: {
+    type: String,
+    default: "22",
+  },
+  height: {
+    type: String,
+    default: "22",
+  },
 });
 const variantClasses = computed(() => ({
   gray: "bg-oc-gray-100 text-oc-gray-700",
@@ -27,6 +35,6 @@ const variantClasses = computed(() => ({
     class="rounded-full p-3 flex items-center justify-center aspect-square"
     :class="variantClasses[variant]"
   >
-    <Icon :name="icon" width="22" height="22" />
+    <Icon :name="icon" :width="width" :height="height" />
   </div>
 </template>

--- a/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverviewItem.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverviewItem.vue
@@ -13,6 +13,14 @@ defineProps({
   isCard: Boolean,
   isLoading: Boolean,
   percentValue: Number,
+  iconWidth: {
+    type: String,
+    default: "22",
+  },
+  iconHeight: {
+    type: String,
+    default: "22",
+  },
 });
 </script>
 
@@ -33,7 +41,13 @@ defineProps({
         class="flex items-center"
         :class="isBig ? 'gap-x-[.75rem]' : 'gap-x-3'"
       >
-        <OverviewIcon v-if="icon" :icon="icon" :variant="variant" />
+        <OverviewIcon
+          v-if="icon"
+          :icon="icon"
+          :variant="variant"
+          :height="iconHeight"
+          :width="iconWidth"
+        />
         <div class="flex flex-col gap-y-px font-medium overflow-hidden">
           <template v-if="percentValue !== undefined">
             <div class="flex items-center gap-x-3 overflow-hidden">


### PR DESCRIPTION
Added height and width props for `OverviewIcon` and same for `OverviewItem` for more flexibility when using the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced customizable icon size for the Overview display through `width` and `height` properties, enhancing visual customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->