### PR TITLE
pass icon dimensions props from overview to items

### DIFF
--- a/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverview.vue
+++ b/packages/@orchidui-vue/src/DataDisplay/Overview/OcOverview.vue
@@ -28,6 +28,8 @@ defineProps({
         :is-loading="isLoading"
         :content="item.content"
         :info="item.info"
+        :icon-height="icon.iconHeight"
+        :icon-width="icon.iconWidth"
       >
         <template v-if="item.isWarning" #warning>
           <slot name="warning" />


### PR DESCRIPTION
Follow up PR to https://github.com/hit-pay/orchid/pull/424
- Pass icon height and width props from `OcOverview` to the the child `OcOverviewItem` components