### PR TITLE
chore/OcSelect avoiding selected option value overflowing component

### DIFF
--- a/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
+++ b/packages/@orchidui-vue/src/Form/Select/OcSelect.vue
@@ -257,7 +257,7 @@ onMounted(() => {
           }}</span>
         </div>
         <template v-else>
-          <span class="whitespace-nowrap flex gap-x-3 items-center">
+          <span class="overflow-hidden whitespace-nowrap flex gap-x-3 items-center">
             <Icon v-if="icon" :name="icon" width="16" height="16" />
 
             <span v-if="isInlineLabel && label" class="text-oc-text-300">


### PR DESCRIPTION
Adding css rule to avoid component overflow

|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/3ec8ff9d-08f4-4632-87ec-30d9c7df3df9)|![image](https://github.com/hit-pay/orchid/assets/4713316/0c671ff9-0f1b-4972-813a-380998cfeff2)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual styling of the select component for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->