### PR TITLE
emit names of expanded submenus in sidebar

### DIFF
--- a/packages/@orchidui-vue/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/@orchidui-vue/src/Elements/Sidebar/OcSidebar.vue
@@ -2,7 +2,11 @@
 import { ref, reactive, onMounted, computed } from "vue";
 import { Icon, SidebarSubmenu, Dropdown } from "@/orchidui";
 
-const emit = defineEmits(["changeExpanded", "click:sidebar-icon"]);
+const emit = defineEmits([
+  "changeExpanded",
+  "click:sidebar-icon",
+  "changeExpandedMenus",
+]);
 
 const props = defineProps({
   class: {
@@ -30,6 +34,8 @@ const expandMenu = (id) => {
   } else {
     state.expanded = state.expanded.filter((menuId) => menuId !== id);
   }
+
+  emit("changeExpandedMenus", state.expanded);
 };
 
 const changeExpanded = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the sidebar to emit an event when menus are expanded or collapsed, enhancing interactivity and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->