### PR TITLE
orc-hit-6312-customer-display-address-remove-commas

### DIFF
--- a/packages/vue/src/DataDisplay/CustomerCard/OcCustomerCard.vue
+++ b/packages/vue/src/DataDisplay/CustomerCard/OcCustomerCard.vue
@@ -102,7 +102,7 @@ const emit = defineEmits(["addCustomer", "editCustomer", "closeCustomer"]);
                 customer?.address?.postal_code || '',
                 customer?.address.country || '',
               ]
-                .join(', ')
+                .join(' ')
                 .trim() || '-'
             "
           />


### PR DESCRIPTION
- changed the separator in address display from ", " to " "

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the display logic for customer address details in the customer card, removing the comma separator for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->