### PR TITLE
[HIT-6364] Created sandbox banner component

### DIFF
--- a/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.js
+++ b/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.js
@@ -1,0 +1,3 @@
+import SandboxBanner from "./OcSandboxBanner.vue";
+
+export { SandboxBanner };

--- a/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.stories.js
+++ b/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.stories.js
@@ -1,0 +1,27 @@
+import SandboxBanner from "./OcSandboxBanner.vue";
+
+export default {
+  component: SandboxBanner,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    title: "You are using test data. Real money won’t be charged",
+    chipProps: {
+      label: "Sandbox Banner",
+      variant: "light-red",
+    },
+  },
+  render: (args) => ({
+    components: {
+      SandboxBanner,
+    },
+    setup() {
+      return { args };
+    },
+    template: `
+          <SandboxBanner :title="args.title" :chipProps="args.chipProps"/>
+        `,
+  }),
+};

--- a/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.vue
+++ b/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.vue
@@ -18,11 +18,9 @@ defineProps({
     class="w-screen relative h-[40px] bg-oc-error flex items-center justify-center text-white"
   >
     <span>
-      {{ title || "You are using test data. Real money won’t be charged" }}
+      {{ title }}
     </span>
 
     <Chip v-if="chipProps" class="absolute left-[40px]" v-bind="chipProps" />
   </div>
 </template>
-
-<style scoped lang="scss"></style>

--- a/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.vue
+++ b/packages/vue/src/Elements/SandboxBanner/OcSandboxBanner.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { Chip } from "@/orchidui";
+
+defineProps({
+  title: {
+    type: String,
+    default: "",
+  },
+  chipProps: {
+    type: Object,
+    default: () => null,
+  },
+});
+</script>
+
+<template>
+  <div
+    class="w-screen relative h-[40px] bg-oc-error flex items-center justify-center text-white"
+  >
+    <span>
+      {{ title || "You are using test data. Real money won’t be charged" }}
+    </span>
+
+    <Chip v-if="chipProps" class="absolute left-[40px]" v-bind="chipProps" />
+  </div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/packages/vue/src/Feedback/Chip/OcChip.vue
+++ b/packages/vue/src/Feedback/Chip/OcChip.vue
@@ -42,6 +42,9 @@ const className = computed(() => {
     case "gray":
       className = "bg-oc-gray-100 text-oc-gray-700 ";
       break;
+    case "light-red":
+      className = "bg-oc-error-50 text-oc-error";
+      break;
     default:
       className = "bg-oc-primary-50 text-oc-primary ";
       break;
@@ -71,6 +74,9 @@ const iconColor = computed(() => {
       break;
     case "gray":
       className = "text-oc-gray-400 ";
+      break;
+    case "light-red":
+      className = "text-oc-error ";
       break;
     default:
       className = "text-oc-primary-300 ";

--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -21,6 +21,7 @@ export * from "./Elements/EmptyPage/OcEmptyPage.js";
 export * from "./Elements/AdditionalContent/OcAdditionalContent.js";
 export * from "./Elements/Skeleton/OcSkeleton.js";
 export * from "./Elements/FeatureOverviewCard/OcFeatureOverviewCard.js";
+export * from "./Elements/SandboxBanner/OcSandboxBanner.js";
 
 export * from "./Feedback/Chip/OcChip.js";
 export * from "./Feedback/Snackbar/OcSnackbar.js";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the `OcSandboxBanner` component for displaying a sandbox environment alert with an optional chip to indicate the use of test data without real charges.
	- Added a new color variant "light-red" for the `OcChip` component to enhance visual cues.

- **Documentation**
	- Added a story for the `OcSandboxBanner` component to illustrate its usage with test data.

- **Refactor**
	- Updated export mechanisms to include the new `OcSandboxBanner` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->