### PR TITLE
add ability to choose indefinite date on calendar

### DIFF
--- a/packages/vue/src/Form/Calendar/OcCalendar.stories.js
+++ b/packages/vue/src/Form/Calendar/OcCalendar.stories.js
@@ -1,4 +1,4 @@
-import { Theme, Calendar } from "@/orchidui";
+import { Theme, Calendar, Checkbox } from "@/orchidui";
 import { ref } from "vue";
 import dayjs from "dayjs";
 
@@ -22,17 +22,23 @@ export const calendarStory = {
       control: "select",
       options: ["floating", "inline"],
     },
+    isIndefinite: {
+      control: "boolean",
+      description: "Whether the calendar is indefinite or not",
+    },
   },
   args: {
     type: "default",
     minDate: "",
     maxDate: "",
     position: "floating",
+    isIndefinite: false,
   },
   render: (args) => ({
     components: {
       Theme,
       Calendar,
+      Checkbox
     },
     setup() {
       const modelValue = ref();
@@ -45,7 +51,7 @@ export const calendarStory = {
             <div class="flex gap-x-6 justify-around">
               <div class="gap-y-4 flex flex-col basis-1/2">
                 <span class="text-xl font-bold">Default Calendar</span>
-                <Calendar v-model="modelValue" v-bind="args" type="default"/>
+                <Calendar v-model="modelValue" v-bind="args" type="default">
                 <span v-if="modelValue">{{ modelValue }}</span>
               </div>
               <div class="gap-y-4 flex flex-col basis-1/2">

--- a/packages/vue/src/Form/Calendar/OcCalendar.vue
+++ b/packages/vue/src/Form/Calendar/OcCalendar.vue
@@ -203,7 +203,6 @@ const isDayInRange = (day) => {
 
 const isDayDisabled = (day) => {
   const currentDate = dayjs(selectedDate.value).date(day);
-  console.log('currentDate', currentDate)
   return (
     props.disabledDate(currentDate.toDate()) ||
     (props.minDate && currentDate.isBefore(dayjs(props.minDate), "day")) ||
@@ -237,9 +236,7 @@ const doneSelecting = () => {
 
 const isCalendarIndefinite = ref(false);
 const handleIndefinite = (value) => {
-  console.log('value', value)
   emit("update:isIndefinite", value);
-  // isCalendarIndefinite.value = value;
 };
 </script>
 

--- a/packages/vue/src/Form/Calendar/OcCalendar.vue
+++ b/packages/vue/src/Form/Calendar/OcCalendar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Button, Icon } from "@/orchidui";
+import { Button, Icon, Checkbox } from "@/orchidui";
 import { computed, ref } from "vue";
 import dayjs from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
@@ -39,8 +39,16 @@ const props = defineProps({
     type: Function,
     default: () => false,
   },
+  isIndefinite: {
+    type: Boolean,
+    default: false,
+  },
+  inDefiniteLabel: {
+    type: String,
+    default: 'Indefinite'
+  }
 });
-const emit = defineEmits(["update:modelValue", "resetCalendar"]);
+const emit = defineEmits(["update:modelValue", "resetCalendar", "update:isIndefinite"]);
 
 const selectedDate = ref(
   props.type === "range"
@@ -195,6 +203,7 @@ const isDayInRange = (day) => {
 
 const isDayDisabled = (day) => {
   const currentDate = dayjs(selectedDate.value).date(day);
+  console.log('currentDate', currentDate)
   return (
     props.disabledDate(currentDate.toDate()) ||
     (props.minDate && currentDate.isBefore(dayjs(props.minDate), "day")) ||
@@ -225,6 +234,13 @@ const doneSelecting = () => {
       : selectedStartDate.value.toDate(),
   );
 };
+
+const isCalendarIndefinite = ref(false);
+const handleIndefinite = (value) => {
+  console.log('value', value)
+  emit("update:isIndefinite", value);
+  // isCalendarIndefinite.value = value;
+};
 </script>
 
 <template>
@@ -233,8 +249,12 @@ const doneSelecting = () => {
     :class="position === 'floating' ? 'shadow-normal bg-white' : ''"
   >
     <div class="flex items-center justify-between">
-      <span>{{ selectedMonth }}</span>
-      <div class="flex gap-x-3">
+      <span
+        :class="[isCalendarIndefinite ? 'pointer-events-none opacity-[.35]' : '']"
+      >
+        {{ selectedMonth }}
+      </span>
+      <div class="flex gap-x-3" :class="[isCalendarIndefinite ? 'pointer-events-none opacity-[.35]' : '']" >
         <Icon
           name="chevron-down"
           class="rotate-90 cursor-pointer"
@@ -277,6 +297,14 @@ const doneSelecting = () => {
         {{ day }}
       </div>
     </div>
+
+    <slot name="bottom">
+      <span
+        v-if="isIndefinite"
+      >
+          <Checkbox v-model="isCalendarIndefinite" :label="inDefiniteLabel" @update:model-value="handleIndefinite" />
+      </span>
+    </slot>
 
     <div class="flex gap-x-3 justify-end">
       <Button

--- a/packages/vue/src/Form/Checkbox/OcCheckbox.stories.js
+++ b/packages/vue/src/Form/Checkbox/OcCheckbox.stories.js
@@ -34,12 +34,16 @@ export const Default = {
                   :is-disabled="args.isDisabled"
                   v-model="value"
               >
-              
+
               <template #after>
                 After
               </template>
               </Checkbox>
             </div>
+            <div>
+                Model value:
+                {{ value }}
+              </div>
           </Theme>
         `,
   }),

--- a/packages/vue/src/Form/DatePicker/DatePicker.vue
+++ b/packages/vue/src/Form/DatePicker/DatePicker.vue
@@ -125,14 +125,8 @@ const disableAllDates = (value) => {
 const isCalendarIndefinite = ref(false);
 
 const handleIndefinite = (event) => {
-  console.log('event from calendar', event)
-  if (event) {
-    // emit("update:modelValue", 'Indefinite');
-    isCalendarIndefinite.value = true;
-  } else {
-    isCalendarIndefinite.value = false;
-  }
-  event ? emit("update:modelValue", 'Indefinite') : emit("update:modelValue", null);
+  isCalendarIndefinite.value = event;
+  emit("update:modelValue", event ?  "Indefinite" : null);
 }
 </script>
 

--- a/packages/vue/src/Form/DatePicker/DatePicker.vue
+++ b/packages/vue/src/Form/DatePicker/DatePicker.vue
@@ -70,6 +70,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  isIndefinite: {
+    type: Boolean,
+    default: true
+  }
 });
 
 const isDropdownOpened = ref(false);
@@ -111,6 +115,25 @@ const resetCalendar = () => {
 };
 
 const defaultDateRange = () => [dayjs().toDate(), dayjs().toDate()];
+
+const disableAllDates = (value) => {
+  const date = dayjs(value);
+  const isInCurrentMonth = (date) => date.get('month') === dayjs().get('month');
+  return isInCurrentMonth(date);
+}
+
+const isCalendarIndefinite = ref(false);
+
+const handleIndefinite = (event) => {
+  console.log('event from calendar', event)
+  if (event) {
+    // emit("update:modelValue", 'Indefinite');
+    isCalendarIndefinite.value = true;
+  } else {
+    isCalendarIndefinite.value = false;
+  }
+  event ? emit("update:modelValue", 'Indefinite') : emit("update:modelValue", null);
+}
 </script>
 
 <template>
@@ -128,9 +151,8 @@ const defaultDateRange = () => [dayjs().toDate(), dayjs().toDate()];
               ? modelValue && modelValue[0]
                 ? `${formattedDate[0].format(dateFormat)} - ${formattedDate[1].format(dateFormat)}`
                 : ''
-              : modelValue
-                ? formattedDate.format(dateFormat)
-                : ''
+              : modelValue === 'Indefinite' ? 'Indefinite' : modelValue
+                ? formattedDate.format(dateFormat) : ''
           "
           icon="calendar"
           :label="label"
@@ -187,12 +209,14 @@ const defaultDateRange = () => [dayjs().toDate(), dayjs().toDate()];
               ? formattedDate.toDate()
               : new Date()
         "
-        :disabled-date="disabledDate"
+        :disabled-date="isCalendarIndefinite ? disableAllDates : disabledDate"
         :max-date="maxDate"
         :min-date="minDate"
+        :is-indefinite="isIndefinite"
         position="inline"
         :type="type"
         @update:model-value="updateCalendar"
+        @update:is-indefinite="handleIndefinite"
         @reset-calendar="resetCalendar"
       />
     </template>

--- a/packages/vue/src/Form/DatePicker/OcDatePicker.stories.js
+++ b/packages/vue/src/Form/DatePicker/OcDatePicker.stories.js
@@ -33,6 +33,7 @@ export const Default = {
     isRequired: true,
     label: "Date",
     isSplitInput: true,
+    isIndefinite: true
   },
   render: (args) => ({
     components: { Theme, DatePicker },
@@ -53,8 +54,8 @@ export const Default = {
           <DatePicker
             v-model="model"
             :key="args.type"
-            type="range"
-            :date-format="args.dateFormat"
+            type="default"
+            date-format="DD/MM/YYYY"
             :error-message="args.errorMessage"
             :disabled-date="checkDisableDate"
             :hint="args.hint"
@@ -65,8 +66,9 @@ export const Default = {
             :max-label="args.maxLabel"
             :is-required="args.isRequired"
             :is-split-input="args.isSplitInput"
+            :is-indefinite="args.isIndefinite"
           />
-          
+
           <div class="mt-8">
             DD/MM/YYYY:  {{ model1 }}
             <DatePicker


### PR DESCRIPTION
![image](https://github.com/hit-pay/orchid/assets/28958299/ee6abc51-56fb-48e2-aa53-b24efd0387b8)         ![image](https://github.com/hit-pay/orchid/assets/28958299/dee57493-81f5-4181-81d9-d34f2f334cac)


[Link to figma](https://www.figma.com/file/WwEmXK4bXgFQIDwCfWOXRT/Recurring-Billing?type=design&node-id=949-92235&mode=design&t=qw7OkLH65WykYC5s-4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `isIndefinite` option in Calendar and DatePicker components, allowing users to select an indefinite date range.
	- Added a visual representation of the selected model value in Checkbox components for enhanced user feedback.

- **Enhancements**
	- Improved calendar functionality with new logic to support 'Indefinite' selections, making date picking more versatile.
	- Updated DatePicker component to handle 'Indefinite' values more effectively and to display dates in "DD/MM/YYYY" format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->