### PR TITLE
chore/OcTextEditor: link tooltip overflowing editor area

### DIFF
--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -238,6 +238,9 @@ onMounted(() => {
       :id="`#${id}`"
       ref="quill"
       :content="modelValue"
+      :options="{
+        bounds: `#${id}`
+      }"
       theme="snow"
       content-type="html"
       class="min-h-[200px]"


### PR DESCRIPTION
Adding bounds options to avoid link tooltip to render outside text editor area

|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/b40310b5-95b0-4479-99cc-811346a6f7eb)|![image](https://github.com/hit-pay/orchid/assets/4713316/00797996-bc36-4697-b814-bfdb18721681)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text editing capabilities by introducing a `bounds` option in the text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->