### PR TITLE
chore/OcTextEditor: fix gap between toolbar and text editor

### DIFF
--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -233,231 +233,233 @@ onMounted(() => {
     :tooltip-text="tooltipText"
     :tooltip-options="tooltipOptions"
   >
-    <QuillEditor
-      v-if="id"
-      :id="`#${id}`"
-      ref="quill"
-      :content="modelValue"
-      :options="{
-        bounds: `#${id}`
-      }"
-      theme="snow"
-      content-type="html"
-      class="min-h-[200px]"
-      @update:content="checkStates"
-      @paste="isValidPasedText"
-    >
-      <template #toolbar>
-        <div
-          :id="id"
-          class="flex min-h-[36px] flex-wrap !py-2 !px-3 gap-x-5 gap-y-2 rounded-t"
-        >
-          <template v-if="toolbar.includes('changes')">
-            <div class="flex items-center gap-x-3">
-              <Icon
-                :class="
-                  isUndoActive
-                    ? 'text-oc-text cursor-pointer'
-                    : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/undo"
-                @click="undo"
-              />
-              <Icon
-                :class="
-                  isRedoActive
-                    ? 'text-oc-text cursor-pointer'
-                    : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/redo"
-                @click="redo"
-              />
-            </div>
-
-            <div class="border-l border-oc-gray-200" />
-          </template>
-
-          <template v-if="toolbar.includes('font-size')">
-            <Dropdown v-model="isSizeActive">
-              <div class="flex items-center gap-x-5 cursor-pointer">
-                {{ fontSizes.find((font) => font.value === activeSize)?.label }}
+    <div>
+      <QuillEditor
+        v-if="id"
+        :id="`#${id}`"
+        ref="quill"
+        :content="modelValue"
+        :options="{
+          bounds: `#${id}`
+        }"
+        theme="snow"
+        content-type="html"
+        class="min-h-[200px]"
+        @update:content="checkStates"
+        @paste="isValidPasedText"
+      >
+        <template #toolbar>
+          <div
+            :id="id"
+            class="flex min-h-[36px] flex-wrap !py-2 !px-3 gap-x-5 gap-y-2 rounded-t"
+          >
+            <template v-if="toolbar.includes('changes')">
+              <div class="flex items-center gap-x-3">
                 <Icon
+                  :class="
+                    isUndoActive
+                      ? 'text-oc-text cursor-pointer'
+                      : 'text-oc-text-300'
+                  "
                   width="20"
                   height="20"
-                  name="chevron-down"
-                  class="transition-all"
-                  :class="isSizeActive ? 'rotate-180' : ''"
+                  name="text-editor/undo"
+                  @click="undo"
+                />
+                <Icon
+                  :class="
+                    isRedoActive
+                      ? 'text-oc-text cursor-pointer'
+                      : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/redo"
+                  @click="redo"
                 />
               </div>
-              <template #menu>
-                <div class="flex flex-col py-2 overflow-hidden">
-                  <div
-                    v-for="fontSize in fontSizes"
-                    :key="fontSize.value"
-                    class="min-w-[120px] cursor-pointer py-2 px-3 hover:bg-oc-gray-50"
-                    :class="activeSize === fontSize.value ? 'font-medium' : ''"
-                    @click="setSize(fontSize.value)"
-                  >
-                    {{ fontSize.label }}
-                  </div>
+  
+              <div class="border-l border-oc-gray-200" />
+            </template>
+  
+            <template v-if="toolbar.includes('font-size')">
+              <Dropdown v-model="isSizeActive">
+                <div class="flex items-center gap-x-5 cursor-pointer">
+                  {{ fontSizes.find((font) => font.value === activeSize)?.label }}
+                  <Icon
+                    width="20"
+                    height="20"
+                    name="chevron-down"
+                    class="transition-all"
+                    :class="isSizeActive ? 'rotate-180' : ''"
+                  />
                 </div>
-              </template>
-            </Dropdown>
-
-            <div class="border-l border-oc-gray-200" />
-          </template>
-
-          <template v-if="toolbar.includes('font-style')">
-            <div class="flex gap-x-3 items-center">
+                <template #menu>
+                  <div class="flex flex-col py-2 overflow-hidden">
+                    <div
+                      v-for="fontSize in fontSizes"
+                      :key="fontSize.value"
+                      class="min-w-[120px] cursor-pointer py-2 px-3 hover:bg-oc-gray-50"
+                      :class="activeSize === fontSize.value ? 'font-medium' : ''"
+                      @click="setSize(fontSize.value)"
+                    >
+                      {{ fontSize.label }}
+                    </div>
+                  </div>
+                </template>
+              </Dropdown>
+  
+              <div class="border-l border-oc-gray-200" />
+            </template>
+  
+            <template v-if="toolbar.includes('font-style')">
+              <div class="flex gap-x-3 items-center">
+                <Icon
+                  class="cursor-pointer"
+                  :class="isBoldActive ? 'text-oc-text' : 'text-oc-text-300'"
+                  width="20"
+                  height="20"
+                  name="text-editor/bold"
+                  @click="setBold"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="isItalicActive ? 'text-oc-text' : 'text-oc-text-300'"
+                  width="20"
+                  height="20"
+                  name="text-editor/italic"
+                  @click="setItalic"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="isUnderlineActive ? 'text-oc-text' : 'text-oc-text-300'"
+                  width="20"
+                  height="20"
+                  name="text-editor/underline"
+                  @click="setUnderline"
+                />
+              </div>
+  
+              <div class="border-l border-oc-gray-200" />
+            </template>
+  
+            <div class="flex items-center gap-x-3">
               <Icon
+                v-if="toolbar.includes('link')"
                 class="cursor-pointer"
-                :class="isBoldActive ? 'text-oc-text' : 'text-oc-text-300'"
                 width="20"
                 height="20"
-                name="text-editor/bold"
-                @click="setBold"
+                name="text-editor/link"
+                @click="setLink"
               />
               <Icon
+                v-if="toolbar.includes('image')"
                 class="cursor-pointer"
-                :class="isItalicActive ? 'text-oc-text' : 'text-oc-text-300'"
                 width="20"
                 height="20"
-                name="text-editor/italic"
-                @click="setItalic"
+                name="text-editor/image"
+                @click="uploadImage"
               />
               <Icon
+                v-if="toolbar.includes('quote')"
                 class="cursor-pointer"
-                :class="isUnderlineActive ? 'text-oc-text' : 'text-oc-text-300'"
+                :class="isBlockquoteActive ? 'text-oc-text' : 'text-oc-text-300'"
                 width="20"
                 height="20"
-                name="text-editor/underline"
-                @click="setUnderline"
+                name="text-editor/quote"
+                @click="setBlockquote"
+              />
+              <Icon
+                v-if="toolbar.includes('media')"
+                class="cursor-pointer"
+                width="20"
+                height="20"
+                name="text-editor/media"
+                @click="uploadVideo"
               />
             </div>
-
-            <div class="border-l border-oc-gray-200" />
-          </template>
-
-          <div class="flex items-center gap-x-3">
-            <Icon
-              v-if="toolbar.includes('link')"
-              class="cursor-pointer"
-              width="20"
-              height="20"
-              name="text-editor/link"
-              @click="setLink"
-            />
-            <Icon
-              v-if="toolbar.includes('image')"
-              class="cursor-pointer"
-              width="20"
-              height="20"
-              name="text-editor/image"
-              @click="uploadImage"
-            />
-            <Icon
-              v-if="toolbar.includes('quote')"
-              class="cursor-pointer"
-              :class="isBlockquoteActive ? 'text-oc-text' : 'text-oc-text-300'"
-              width="20"
-              height="20"
-              name="text-editor/quote"
-              @click="setBlockquote"
-            />
-            <Icon
-              v-if="toolbar.includes('media')"
-              class="cursor-pointer"
-              width="20"
-              height="20"
-              name="text-editor/media"
-              @click="uploadVideo"
-            />
+  
+            <template v-if="toolbar.includes('list')">
+              <div class="border-l border-oc-gray-200" />
+  
+              <div class="flex gap-x-3 items-center">
+                <Icon
+                  class="cursor-pointer"
+                  :class="
+                    activeListFormat === 'bullet'
+                      ? 'text-oc-text'
+                      : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/bullet"
+                  @click="setListFormat('bullet')"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="
+                    activeListFormat === 'ordered'
+                      ? 'text-oc-text'
+                      : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/number"
+                  @click="setListFormat('ordered')"
+                />
+              </div>
+            </template>
+  
+            <template v-if="toolbar.includes('alignment')">
+              <div class="border-l border-oc-gray-200" />
+  
+              <div class="flex gap-x-3 items-center">
+                <Icon
+                  class="cursor-pointer"
+                  :class="!activeAlign ? 'text-oc-text' : 'text-oc-text-300'"
+                  width="20"
+                  height="20"
+                  name="text-editor/left"
+                  @click="setAlign()"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="
+                    activeAlign === 'center' ? 'text-oc-text' : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/center"
+                  @click="setAlign('center')"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="
+                    activeAlign === 'right' ? 'text-oc-text' : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/right"
+                  @click="setAlign('right')"
+                />
+                <Icon
+                  class="cursor-pointer"
+                  :class="
+                    activeAlign === 'justify'
+                      ? 'text-oc-text'
+                      : 'text-oc-text-300'
+                  "
+                  width="20"
+                  height="20"
+                  name="text-editor/justify"
+                  @click="setAlign('justify')"
+                />
+              </div>
+            </template>
           </div>
-
-          <template v-if="toolbar.includes('list')">
-            <div class="border-l border-oc-gray-200" />
-
-            <div class="flex gap-x-3 items-center">
-              <Icon
-                class="cursor-pointer"
-                :class="
-                  activeListFormat === 'bullet'
-                    ? 'text-oc-text'
-                    : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/bullet"
-                @click="setListFormat('bullet')"
-              />
-              <Icon
-                class="cursor-pointer"
-                :class="
-                  activeListFormat === 'ordered'
-                    ? 'text-oc-text'
-                    : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/number"
-                @click="setListFormat('ordered')"
-              />
-            </div>
-          </template>
-
-          <template v-if="toolbar.includes('alignment')">
-            <div class="border-l border-oc-gray-200" />
-
-            <div class="flex gap-x-3 items-center">
-              <Icon
-                class="cursor-pointer"
-                :class="!activeAlign ? 'text-oc-text' : 'text-oc-text-300'"
-                width="20"
-                height="20"
-                name="text-editor/left"
-                @click="setAlign()"
-              />
-              <Icon
-                class="cursor-pointer"
-                :class="
-                  activeAlign === 'center' ? 'text-oc-text' : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/center"
-                @click="setAlign('center')"
-              />
-              <Icon
-                class="cursor-pointer"
-                :class="
-                  activeAlign === 'right' ? 'text-oc-text' : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/right"
-                @click="setAlign('right')"
-              />
-              <Icon
-                class="cursor-pointer"
-                :class="
-                  activeAlign === 'justify'
-                    ? 'text-oc-text'
-                    : 'text-oc-text-300'
-                "
-                width="20"
-                height="20"
-                name="text-editor/justify"
-                @click="setAlign('justify')"
-              />
-            </div>
-          </template>
-        </div>
-      </template>
-    </QuillEditor>
+        </template>
+      </QuillEditor>
+    </div>
   </BaseInput>
 </template>
 


### PR DESCRIPTION
Wrapping QuillEditor with a div container
|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/0b354015-5127-4fc8-9a07-9230f5f73793)|![image](https://github.com/hit-pay/orchid/assets/4713316/84ad3fe2-c414-44c7-8e09-02d4fe596d68)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the structure and layout of the text editor and its toolbar for enhanced usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->