### PR TITLE
fix/modify-draggable-content

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.75",
+  "version": "0.5.81",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Elements/Draggable/OcDraggable.stories.js
+++ b/packages/vue/src/Elements/Draggable/OcDraggable.stories.js
@@ -10,7 +10,12 @@ export default {
   tags: ["autodocs"],
 };
 
+const args = {
+    classes: 'hover:shadow bg-oc-background-light hover:bg-oc-accent-1-50'
+  }
+
 export const OcDraggableList = {
+  args,
   render: (args) => ({
     components: {
       Theme,
@@ -18,6 +23,7 @@ export const OcDraggableList = {
       Toggle,
       DropdownItem,
     },
+
     setup() {
       const model = ref([
         {
@@ -31,6 +37,7 @@ export const OcDraggableList = {
           id: "234",
           title: "234 Label ",
           beforeAction: true,
+          link: 'https://orchidui.vercel.app'
         },
         {
           id: "456",
@@ -114,7 +121,20 @@ export const OcDraggableList = {
           <Theme>
             <div class="p-4">{{ model}}</div>
             <div class="w-full min-h-[200px]">
-              <DraggableList v-model="model" is-link>
+              <DraggableList v-model="model" is-link :classes="args.classes">
+                <template #title="{item}">
+                    <div class="flex w-full">
+                      <div class="flex justify-between w-full">
+                        <div class="flex flex-col">
+                          <span class="mb-2">{{ item.title }}</span>
+                          <span> {{ item.link }} </span>
+                        </div>
+                        <div class="flex items-center">
+                          <span>{{ item.id }} </span>
+                        </div>
+                      </div>
+                    </div>
+                </template>
                 <template #action-item="{item}">
                     <DropdownItem text="Menu" icon="pencil" @click="isOpenedDropdown=false"/>
                     <DropdownItem text="Menu" icon="pencil" @click="isOpenedDropdown=false"/>

--- a/packages/vue/src/Elements/Draggable/OcDraggableList.vue
+++ b/packages/vue/src/Elements/Draggable/OcDraggableList.vue
@@ -21,6 +21,10 @@ defineProps({
     default: "link",
   },
   isDisabled: Boolean,
+  classes: {
+    type: String,
+    default: "",
+  },
 });
 defineEmits({
   "update:modelValue": [],
@@ -33,18 +37,19 @@ const isDropdownOpen = ref([]);
   <Draggable
     v-slot="{ list }"
     :model-value="modelValue"
-    class="grid gap-3"
+    class="grid gap-5"
     @update:model-value="$emit('update:modelValue', $event)"
   >
+    <!-- wrapper -->
     <div
       v-for="element in list"
       :key="element.id"
-      class="group text-oc-text-500 p-4 flex flex-wrap items-center rounded border border-gray-200"
+      class="group text-oc-text-500 p-6 flex flex-col w-full rounded border border-gray-200 cursor-pointer"
       :class="
         element[childrenKey]
           ? 'hover:shadow bg-oc-gray-50'
           : isChildren && !isHovered[element.id]
-            ? 'bg-oc-accent-1-50'
+            ? 'bg-oc-accent-1-50' : classes ? classes
             : 'hover:shadow bg-oc-accent-1-50 hover:bg-oc-gray-50'
       "
       @mouseleave="
@@ -54,87 +59,107 @@ const isDropdownOpen = ref([]);
       @mouseover="isHovered[element.id] = true"
       @click="$emit('click:element', element)"
     >
-      <div
-        class="px-2 flex"
-        :class="!isDisabled && !element.isDisable ? 'drag-el cursor-move' : ''"
-      >
-        <Icon
-          v-if="!isDisabled && !element.isDisable"
-          name="draggable"
-          :class="
-            element[iconKey]
-              ? isChildren && !isHovered[element.id]
-                ? 'hidden'
-                : 'hidden group-hover:block'
-              : isChildren && !isHovered[element.id]
-                ? 'opacity-0'
-                : 'opacity-0 group-hover:opacity-100 '
-          "
-        />
-        <Icon
-          v-if="element[iconKey]"
-          :name="element[iconKey]"
-          :class="
-            !isDisabled && !element.isDisable && isHovered[element.id]
-              ? 'group-hover:hidden'
-              : ''
-          "
-        />
-      </div>
-      <div class="ml-2 flex items-center max-w-[70%]">
-        <div class="flex items-center flex-wrap">
-          <div class="truncate">
-            {{ element.title }}
-          </div>
-          <a
-            v-if="isLink && element[linkKey] && element.type === 'link'"
-            :href="element[linkKey]"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="w-full flex items-center text-oc-text-300 mt-2"
-          >
-            <Tooltip
-              distance="2"
-              position="bottom-start"
-              popper-class="bg-oc-bg-light text-oc-text-500 p-4 rounded"
-            >
-              <Icon width="12" height="12" class="mr-2" name="link" />
-              <template #popper>
-                <div class="min-w-[120px]">
-                  {{ element[linkKey] }}
-                </div>
-              </template>
-            </Tooltip>
-            <span class="truncate w-[200px]"> {{ element[linkKey] }}</span>
-          </a>
-        </div>
-      </div>
-      <div class="flex ml-auto">
-        <slot name="before-action" :item="element"></slot>
-        <slot name="action" :item="element">
-          <Dropdown
-            v-model="isDropdownOpen[element.id]"
-            placement="bottom-end"
-            class="cursor-pointer"
-            :class="
-              isChildren && !isHovered[element.id]
-                ? 'opacity-0'
-                : 'opacity-0 group-hover:opacity-100'
-            "
-          >
+
+      <!-- top content -->
+      <div class="flex justify-evenly w-full">
+
+        <!-- icon and title content -->
+        <div class="flex w-full">
+            <!-- icon -->
             <div
-              class="hover:bg-oc-gray-100 p-1 rounded"
-              :class="isDropdownOpen[element.id] ? 'bg-oc-gray-100' : ''"
+              class="px-2 flex items-center"
+              :class="!isDisabled && !element.isDisable ? 'drag-el cursor-move' : ''"
             >
-              <Icon name="dots-vertical" />
+              <Icon
+                v-if="!isDisabled && !element.isDisable"
+                name="draggable"
+                :class="
+                  element[iconKey]
+                    ? isChildren && !isHovered[element.id]
+                      ? 'hidden'
+                      : 'hidden group-hover:block'
+                    : isChildren && !isHovered[element.id]
+                      ? 'opacity-0'
+                      : 'opacity-0 group-hover:opacity-100 '
+                "
+              />
+              <Icon
+                v-if="element[iconKey]"
+                :name="element[iconKey]"
+                :class="
+                  !isDisabled && !element.isDisable && isHovered[element.id]
+                    ? 'group-hover:hidden'
+                    : ''
+                "
+              />
             </div>
-            <template #menu>
-              <slot name="action-item" :item="element"></slot>
-            </template>
-          </Dropdown>
-        </slot>
+
+            <!-- title -->
+            <div class="ml-4 flex w-full">
+                <div class="flex items-center flex-wrap w-full">
+                  <slot name="title" :item="element">
+                    <div class="truncate">
+                      {{ element.title }}
+                    </div>
+                  </slot>
+
+                  <a
+                    v-if="isLink && element[linkKey] && element.type === 'link'"
+                    :href="element[linkKey]"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="w-full flex items-center text-oc-text-300 mt-2"
+                  >
+                      <Tooltip
+                        distance="2"
+                        position="bottom-start"
+                        popper-class="bg-oc-bg-light text-oc-text-500 p-4 rounded"
+                      >
+                        <Icon width="12" height="12" class="mr-2" name="link" />
+                        <template #popper>
+                          <div class="min-w-[120px]">
+                            {{ element[linkKey] }}
+                          </div>
+                        </template>
+                      </Tooltip>
+                      <span class="truncate w-[200px]"> {{ element[linkKey] }}</span>
+                  </a>
+                </div>
+            </div>
+        </div>
+
+          <!-- action items  -->
+        <div class="flex items-center ml-4">
+            <slot name="before-action" :item="element"></slot>
+            <slot name="action" :item="element">
+              <Dropdown
+                v-model="isDropdownOpen[element.id]"
+                placement="bottom-end"
+                class="cursor-pointer"
+                :class="
+                  isChildren && !isHovered[element.id]
+                    ? 'opacity-0'
+                    : 'opacity-0 group-hover:opacity-100'
+                "
+              >
+                <div
+                  class="hover:bg-oc-gray-100 p-1 rounded"
+                  :class="isDropdownOpen[element.id] ? 'bg-oc-gray-100' : ''"
+                >
+                  <Icon name="dots-vertical" />
+                </div>
+                <template #menu>
+                  <slot name="action-item" :item="element"></slot>
+                </template>
+              </Dropdown>
+            </slot>
+          </div>
       </div>
-      <slot name="content" :item="element" />
+
+      <!-- extra content -->
+      <div class="flex w-full">
+        <slot name="content" :item="element" />
+      </div>
     </div>
   </Draggable>
 </template>


### PR DESCRIPTION
- modify draggable component on orchid to match design
- add props to conditionally choose the color of the draggable component

BEFORE:

<img width="973" alt="image" src="https://github.com/hit-pay/orchid/assets/28958299/7b04e9fa-2072-4d23-9a50-ab3901a272ab">


AFTER:
<img width="1013" alt="image" src="https://github.com/hit-pay/orchid/assets/28958299/dc43cd30-a6ec-4166-a11a-2530329fbe8f">


DESIGN:
<img width="427" alt="image" src="https://github.com/hit-pay/orchid/assets/28958299/2870dd8b-2f81-47bf-9e9e-2c3ca641f9f5">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Draggable List component with customizable classes for styling flexibility.
	- Added the ability to include links in draggable list items.
	- Improved visual appeal and user interaction with updated padding, cursor styles, and structured content areas within draggable list items.
	- Introduced slots for custom rendering of titles, action items, and additional content in the draggable list, allowing for more tailored user experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->