### PR TITLE
chore/OcTextEditor: fix container overflow

### DIFF
--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -233,7 +233,7 @@ onMounted(() => {
     :tooltip-text="tooltipText"
     :tooltip-options="tooltipOptions"
   >
-    <div>
+    <div class="grid">
       <QuillEditor
         v-if="id"
         :id="`#${id}`"


### PR DESCRIPTION
Adding grid class to text editor container

|Before|After|
|-|-|
|![image](https://github.com/hit-pay/orchid/assets/4713316/02ea08d6-ba92-4571-bdf9-0a3f50448411)|![image](https://github.com/hit-pay/orchid/assets/4713316/adc7175a-d0f9-485b-929a-6e624042a0cd)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved layout and styling of the text editor component for a more organized appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->