### PR TITLE
[Chore] Disable date before startday when selecting to input

### DIFF
--- a/packages/vue/src/Form/Calendar/OcCalendar.vue
+++ b/packages/vue/src/Form/Calendar/OcCalendar.vue
@@ -53,7 +53,12 @@ const props = defineProps({
     default: 'Indefinite'
   }
 });
-const emit = defineEmits(["update:modelValue", "resetCalendar", "update:isIndefinite"]);
+const emit = defineEmits([
+  "update:modelValue",
+  "resetCalendar",
+  "start-date-selected",
+  "update:isIndefinite",
+]);
 
 const selectedDate = ref(
   props.type === "range"
@@ -62,6 +67,8 @@ const selectedDate = ref(
 );
 
 const selectedStartDate = ref(selectedDate.value);
+const isCalendarIndefinite = ref(false);
+const isStartDateSet = ref(false);
 
 const selectedEndDate = ref(
   props.type === "range"
@@ -81,8 +88,6 @@ const selectedEndDay = ref(
       : null
     : null,
 );
-
-const isStartDateSet = ref(false);
 
 const daysInMonth = computed(() => {
   const date = selectedDate.value;
@@ -109,7 +114,6 @@ const selectDay = (day) => {
   }
 
   let currentMonth = selectedDate.value.date(day);
-  isStartDateSet.value = selectedStartDay.value === selectedEndDay.value;
 
   if (selectedStartDay.value && props.dateSelecting === 'to') {
     selectedEndDay.value = day;
@@ -119,13 +123,14 @@ const selectDay = (day) => {
   }
 
   if (!isStartDateSet.value) {
-    isStartDateSet.value = true;
-
     selectedStartDay.value = day;
     selectedStartDate.value = currentMonth;
 
     selectedEndDay.value = day;
     selectedEndDate.value = currentMonth;
+
+    isStartDateSet.value = true;
+    emit('start-date-selected', dayjs(selectedMonth.value, "MMMM YYYY").date(day))
 
     return;
   }
@@ -248,6 +253,7 @@ const doneSelecting = () => {
     }
   }
 
+  isStartDateSet.value = false;
   emit(
     "update:modelValue",
     isRangeSelection.value
@@ -256,7 +262,6 @@ const doneSelecting = () => {
   );
 };
 
-const isCalendarIndefinite = ref(false);
 const handleIndefinite = (value) => {
   emit("update:isIndefinite", value);
 };

--- a/packages/vue/src/Form/DatePicker/DatePicker.vue
+++ b/packages/vue/src/Form/DatePicker/DatePicker.vue
@@ -76,8 +76,10 @@ const props = defineProps({
   }
 });
 
+const inputTypeSelecting = ref()
+const startDateSelected = ref()
 const isDropdownOpened = ref(false);
-const inputTypeSelecting = ref(undefined)
+const isCalendarIndefinite = ref(false);
 
 const isRangeInput = computed(() => props.type === "range");
 
@@ -95,6 +97,22 @@ const formattedDate = computed(() => {
 
   return ["", ""];
 });
+
+const mintDateComputed = computed(() => {
+  if (props.minDate) {
+    return props.minDate
+  }
+
+  if (isRangeInput.value) {
+    const fromDate = startDateSelected.value ?? formattedDate.value[0];
+
+    return inputTypeSelecting.value === 'from'
+      ? null
+      : dayjs(fromDate).subtract(0, 'day')
+  }
+
+  return null;
+})
 
 const updateCalendar = (newValue) => {
   if (props.type === "range") {
@@ -127,7 +145,10 @@ const disableAllDates = (value) => {
   return isInCurrentMonth(date);
 }
 
-const isCalendarIndefinite = ref(false);
+const selectStartDate = (value) => {
+  selectInput('to');
+  startDateSelected.value = value;
+}
 
 const handleIndefinite = (event) => {
   isCalendarIndefinite.value = event;
@@ -212,11 +233,12 @@ const handleIndefinite = (event) => {
         "
         :disabled-date="isCalendarIndefinite ? disableAllDates : disabledDate"
         :max-date="maxDate"
-        :min-date="minDate"
+        :min-date="mintDateComputed"
         :is-indefinite="isIndefinite"
         position="inline"
         :type="type"
         :date-selecting="inputTypeSelecting"
+        @start-date-selected="selectStartDate"
         @update:model-value="updateCalendar"
         @update:is-indefinite="handleIndefinite"
         @reset-calendar="resetCalendar"


### PR DESCRIPTION
Update UX: https://linear.app/hitpay/issue/HIT-6292/the-date-selector-is-overriding-the-from-when-the-user-is-selecting-to
- Disabled date before from_date when selecting `to` input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Calendar component to support the selection of a start date and indefinite date selection.
	- Updated the DatePicker component to react to start date selections and support indefinite date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->