### PR TITLE
Updated page-title copy value

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.112",
+  "version": "0.5.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.112",
+      "version": "0.5.113",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.112",
+  "version": "0.5.113",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Elements/PageTitle/OcPageTitle.vue
+++ b/packages/vue/src/Elements/PageTitle/OcPageTitle.vue
@@ -7,6 +7,7 @@ defineProps({
   title: { type: String, required: true },
   description: { type: String, default: "" },
   titleClass: { type: String, default: "" },
+  copyValue: { type: String, default: "" },
   primaryButtonProps: Object,
   secondaryButtonProps: Object,
   tooltipOptions: Object,
@@ -46,6 +47,7 @@ defineEmits({
           :title="title"
           :description="description"
           :chip-props="chipProps"
+          :copy-value="copyValue"
           :tooltip-options="tooltipOptions"
           :is-copy="isCopy"
           class="flex-1"

--- a/packages/vue/src/Elements/PageTitle/OcTitle.vue
+++ b/packages/vue/src/Elements/PageTitle/OcTitle.vue
@@ -1,9 +1,11 @@
+323
 <script setup>
 import { Chip, CopyTooltip, Icon } from "@/orchidui";
 
 defineProps({
   title: { type: String, required: true },
   description: { type: String, required: true },
+  copyValue: { type: String, default: "" },
   chipProps: Object,
   tooltipOptions: Object,
   isCopy: Boolean,
@@ -34,7 +36,7 @@ defineProps({
 
       <CopyTooltip
         v-if="isCopy"
-        :value="description"
+        :value="copyValue"
         :tooltip-options="tooltipOptions"
       >
         <template #default="{ isShow }">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the Page Title component with a new `copyValue` feature, allowing users to pass a string value for copying directly from the title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->