### PR TITLE
chore/OcSelect: closing dropdown on pressing Enter

### DIFF
--- a/packages/vue/src/Form/Select/OcSelect.vue
+++ b/packages/vue/src/Form/Select/OcSelect.vue
@@ -291,6 +291,7 @@ defineExpose({
             input-class="!border-none !shadow-none"
             :is-readonly="!isDropdownOpened"
             @update:model-value="$emit('onSearchKeywords', query)"
+            @keyup.enter="isDropdownOpened = false"
           >
             <template v-if="isDropdownOpened" #icon>
               <Icon class="w-5 h-5 text-oc-text-400" name="search" />


### PR DESCRIPTION
Added @keyup.enter event to close dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the dropdown selection experience by allowing users to close the dropdown using the Enter key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->