### PR TITLE
chore/OcSelect: closing dropdown when pressing Enter

### DIFF
--- a/packages/vue/src/Form/Select/OcSelect.vue
+++ b/packages/vue/src/Form/Select/OcSelect.vue
@@ -206,6 +206,7 @@ watch(filterableOptions, () => {
 
 watch(isDropdownOpened, (value) => {
   if (!value) {
+    emit('close');
     return;
   }
 
@@ -245,7 +246,6 @@ defineExpose({
       :popper-style="{ maxWidth: `${maxPopperWidth}px` }"
       :popper-options="popperOptions"
       :is-disabled="isDisabled || isReadonly"
-      @update:model-value="!$event ? $emit('close') : ''"
     >
       <div
         class="border min-h-[36px] w-full px-3 flex justify-between items-center cursor-pointer gap-x-3 rounded"


### PR DESCRIPTION
Emitting close when **`isDropdownOpenened`** is false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown behavior to emit a 'close' event when not opened.

- **Bug Fixes**
	- Removed redundant event handling for model value updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->