### PR TITLE
Add oc-list-item type page

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.176",
+  "version": "0.5.180",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.176",
+      "version": "0.5.180",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.178",
+  "version": "0.5.180",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
+++ b/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
@@ -247,8 +247,9 @@ export const OcListItemPage = {
         description: `<p><span style="font-size:14px;">Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic maxime recusandae velit, assumenda ullam beatae obcaecati ab ad doloremque quia dolores necessitatibus eligendi nulla asperiores modi voluptas totam. Iste, animi.</span></p>`,
         enabled: 1,
         page_path: "page-path-1",
-        page_cover_id: null,
-        page_cover_url: null,
+        page_cover_id: "12345",
+        page_cover_url:
+          "https://blog.hitpayapp.com/content/images/size/w2000/2024/02/-new--Clarissa-Blog-Design---4-.png",
         created_at: "2024-04-18T09:23:39+08:00",
         updated_at: "2024-04-18T09:23:39+08:00",
       },
@@ -276,7 +277,7 @@ export const OcListItemPage = {
       <Theme colorMode="light" class="p-10">
         <ListItem
           type="page"
-          v-bind="args"
+          v-for="page in args.pages" :page="page"
         >
           <template #menu>
             <div class="p-2 border-b border-gray-200">

--- a/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
+++ b/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
@@ -236,3 +236,58 @@ export const ListGeneral = {
     `,
   }),
 };
+
+export const OcListItemPage = {
+  args: {
+    pages: [
+      {
+        id: "9bd54837-2156-417a-9577-8ff20f895769",
+        business_id: "8ba6c772-8c2d-4f3b-a7d6-3f1f0648fa77",
+        title: "Page Title example",
+        description: `<p><span style="font-size:14px;">Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic maxime recusandae velit, assumenda ullam beatae obcaecati ab ad doloremque quia dolores necessitatibus eligendi nulla asperiores modi voluptas totam. Iste, animi.</span></p>`,
+        enabled: 1,
+        page_path: "page-path-1",
+        page_cover_id: null,
+        page_cover_url: null,
+        created_at: "2024-04-18T09:23:39+08:00",
+        updated_at: "2024-04-18T09:23:39+08:00",
+      },
+      {
+        id: "9bb6447e-edab-4c8c-9652-8186cffc8402",
+        business_id: "8ba6c772-8c2d-4f3b-a7d6-3f1f0648fa77",
+        title: "Page Title example",
+        description:
+          '<p><span style="font-size:14px;">Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic maxime recusandae velit, assumenda ullam beatae obcaecati ab ad doloremque.</span></p>',
+        enabled: 0,
+        page_path: "page-path-2",
+        page_cover_id: null,
+        page_cover_url: null,
+        created_at: "2024-04-02T23:22:35+08:00",
+        updated_at: "2024-04-18T09:22:56+08:00",
+      },
+    ],
+  },
+  render: (args) => ({
+    components: { Theme, ListItem, DropdownItem },
+    setup() {
+      return { args };
+    },
+    template: `
+      <Theme colorMode="light" class="p-10">
+        <ListItem
+          type="page"
+          v-bind="args"
+        >
+          <template #menu>
+            <div class="p-2 border-b border-gray-200">
+              <DropdownItem text="Edit" icon="pencil" />
+            </div>
+            <div class="p-2">
+              <DropdownItem text="Delete" variant="destructive" icon="bin"/>
+            </div>
+          </template>
+        </ListItem>
+      </Theme>
+    `,
+  }),
+};

--- a/packages/vue/src/DataDisplay/ListItem/OcListItem.vue
+++ b/packages/vue/src/DataDisplay/ListItem/OcListItem.vue
@@ -5,6 +5,7 @@ import OcWebhook from "./components/OcWebhook.vue";
 import OcPayment from "./components/OcPayment.vue";
 import OcGeneral from "./components/OcGeneral.vue";
 import OcTerminal from "./components/OcTerminal.vue";
+import OcPage from "./components/OcPage.vue";
 
 const props = defineProps({
   isActive: Boolean,
@@ -51,6 +52,8 @@ const getTypeComponent = computed(() => {
       return OcGeneral;
     case "terminal":
       return OcTerminal;
+    case "page":
+      return OcPage;
     default:
       return OcTimeLine;
   }

--- a/packages/vue/src/DataDisplay/ListItem/components/OcGeneral.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcGeneral.vue
@@ -73,7 +73,7 @@ const toggleDashboard = () => {
                 @click.stop="toggleDashboard"
               />
               <template #menu>
-                <div @click="isOpen = false">
+                <div @mouseleave="isOpen = false">
                   <slot name="menu" />
                 </div>
               </template>

--- a/packages/vue/src/DataDisplay/ListItem/components/OcPage.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcPage.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { Chip, Icon, Dropdown } from "@/orchidui";
+import { ref } from "vue";
+defineProps({
+  id: String,
+  title: String,
+  description: String,
+  enabled: Boolean,
+  pagePath: String,
+  pageCoverId: String,
+  pageCoverUrl: String,
+  createdAt: String,
+  updatedAt: String,
+});
+const isOpen = ref(false);
+const toggleActionMenu = () => {
+  isOpen.value = !isOpen.value;
+};
+</script>
+
+<template>
+  <div
+    class="px-5 py-4 rounded border border-gray-200 group hover:shadow-normal"
+  >
+    <div class="flex items-center gap-x-4 w-full">
+      <div class="flex flex-col flex-1 gap-y-2">
+        <div class="flex items-center justify-between">
+          <div
+            class="flex text-sm text-oc-text-400 items-center gap-x-3 overflow-hidden"
+          >
+            <span
+              v-if="title"
+              class="text-base text-oc-text font-medium truncate"
+            >
+              {{ title }}
+            </span>
+          </div>
+          <Dropdown v-model="isOpen" placement="bottom-end">
+            <Icon
+              name="dots-vertical"
+              class="opacity-0 p-2 group-hover:opacity-100 cursor-pointer active:bg-oc-gray-100 rounded"
+              @click.stop="toggleActionMenu"
+            />
+            <template #menu>
+              <div @mouseleave="isOpen = false">
+                <slot name="menu" />
+              </div>
+            </template>
+          </Dropdown>
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="text-oc-text-400 flex gap-x-2 items-center text-sm">
+            {{ description }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/DataDisplay/ListItem/components/OcPage.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcPage.vue
@@ -1,46 +1,43 @@
-<script setup lang="ts">
+<script setup>
 import { Chip, Icon, Dropdown } from "@/orchidui";
 import { ref } from "vue";
+import dayjs from "dayjs";
+
 defineProps({
-  id: String,
-  title: String,
-  description: String,
-  enabled: Boolean,
-  pagePath: String,
-  pageCoverId: String,
-  pageCoverUrl: String,
-  createdAt: String,
-  updatedAt: String,
+  page: Object,
 });
 const isOpen = ref(false);
-const toggleActionMenu = () => {
-  isOpen.value = !isOpen.value;
+const stripHtml = (html) => {
+  let tmp = document.createElement("DIV");
+  tmp.innerHTML = html;
+  return tmp.textContent || tmp.innerText || "";
+};
+
+const getPageThumbnail = (url) => {
+  return url?.replace("generics/medium/", "generics/thumbnail/");
 };
 </script>
 
 <template>
-  <div
-    class="px-5 py-4 rounded border border-gray-200 group hover:shadow-normal"
-  >
-    <div class="flex items-center gap-x-4 w-full">
-      <div class="flex flex-col flex-1 gap-y-2">
-        <div class="flex items-center justify-between">
-          <div
-            class="flex text-sm text-oc-text-400 items-center gap-x-3 overflow-hidden"
-          >
-            <span
-              v-if="title"
-              class="text-base text-oc-text font-medium truncate"
-            >
-              {{ title }}
-            </span>
-          </div>
+  <div class="w-full py-4 px-1 mb-3 flex hover:opacity-90">
+    <div v-if="page.page_cover_url" class="min-w-[100px]">
+      <div
+        class="w-[100px] h-[100px] rounded !bg-cover"
+        :style="`background:url(${getPageThumbnail(page.page_cover_url)})`"
+      ></div>
+    </div>
+    <div class="grow pl-3">
+      <div class="flex w-full">
+        <div class="text-lg font-medium">
+          {{ page.title }}
+        </div>
+        <div class="ml-auto">
           <Dropdown v-model="isOpen" placement="bottom-end">
-            <Icon
-              name="dots-vertical"
-              class="opacity-0 p-2 group-hover:opacity-100 cursor-pointer active:bg-oc-gray-100 rounded"
-              @click.stop="toggleActionMenu"
-            />
+            <div
+              class="cursor-pointer flex hover:bg-oc-gray-200 items-center rounded p-2"
+            >
+              <Icon class="text-oc-text-400" name="dots-vertical" />
+            </div>
             <template #menu>
               <div @mouseleave="isOpen = false">
                 <slot name="menu" />
@@ -48,11 +45,20 @@ const toggleActionMenu = () => {
             </template>
           </Dropdown>
         </div>
-        <div class="flex flex-col gap-3">
-          <div class="text-oc-text-400 flex gap-x-2 items-center text-sm">
-            {{ description }}
-          </div>
-        </div>
+      </div>
+      <div class="line-clamp-2 opacity-70 mb-3 max-w-[80%]">
+        {{ stripHtml(page.description) }}
+      </div>
+      <div class="w-full text-sm lg:mt-4 flex flex-wrap items-center">
+        <span class="mr-3">
+          <span class="text-oc-text-400">Last updated : </span>
+          {{ dayjs(page.updated_at).format("DD MMM YYYY") }}</span
+        >
+        <Chip
+          class="ml-auto md:ml-0"
+          :variant="!page.enabled ? 'gray' : 'primary'"
+          >{{ page.enabled ? "Published" : "Draft" }}</Chip
+        >
       </div>
     </div>
   </div>

--- a/packages/vue/src/DataDisplay/ListItem/components/OcWebhook.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcWebhook.vue
@@ -33,7 +33,9 @@ const isOpen = ref(false);
           @click="$emit('more')"
         />
         <template #menu>
-          <slot name="menu" />
+          <div @mouseleave="isOpen = false">
+            <slot name="menu" />
+          </div>
         </template>
       </Dropdown>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `OcListItemPage` component for displaying lists of pages with detailed properties.
  - Added a new `OcPage` component in list items to handle page-specific content including thumbnails, titles, descriptions, and publication status.
- **Enhancements**
  - Updated list item components to enhance interaction by changing menu close triggers from click to mouse leave.
- **Version Updates**
  - Updated package version from `0.5.178` to `0.5.180`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->