### PR TITLE
Hidden scrollbar in phone-country-list

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.198",
+      "version": "0.5.199",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/PhoneInput/OcPhoneInput.vue
+++ b/packages/vue/src/Form/PhoneInput/OcPhoneInput.vue
@@ -170,7 +170,7 @@ const onPaste = (e) => {
         <template #menu>
           <div
             ref="countryListRef"
-            class="flex flex-col max-h-[300px] py-2 overflow-y-scroll"
+            class="flex flex-col max-h-[300px] py-2 overflow-y-scroll hidden-scrollbar"
           >
             <div class="px-3 py-1 sticky top-0 bg-oc-bg-light z-[1000]">
               <Input
@@ -213,4 +213,14 @@ const onPaste = (e) => {
 
 <style>
 @import url("https://cdn.jsdelivr.net/gh/lipis/flag-icons@latest/css/flag-icons.min.css");
+
+.hidden-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  /* Hide scrollbar for Chrome, Safari and Opera */
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version number of the `@orchidui/vue` package to enhance compatibility and performance.

- **Style**
	- Improved the visual appearance of the phone input form by hiding the scrollbar on Chrome, Safari, and Opera, ensuring a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->