### PR TITLE
Add placeholder to TextEditor

### DIFF
--- a/packages/vue/src/Form/TextEditor/OcTextEditor.stories.js
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.stories.js
@@ -36,6 +36,7 @@ export const Default = {
     ],
     initialFontSize: "14px",
     variant: "default",
+    placeholder: "Placeholder",
   },
   render: (args) => ({
     components: { TextEditor, Theme },

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -49,6 +49,10 @@ const props = defineProps({
     validator: (value) => ["default", "text-only"].includes(value),
     default: "default",
   },
+  placeholder: {
+    type: String,
+    default: "",
+  },
 });
 const emit = defineEmits(["update:modelValue", "update:image"]);
 
@@ -76,7 +80,7 @@ Quill.register(Size, true);
 const id = ref(
   Math.random()
     .toString(36)
-    .replace(/[^a-zA-Z]+/g, "")
+    .replace(/[^a-zA-Z]+/g, ""),
 );
 const isUndoActive = ref(false);
 const isRedoActive = ref(false);
@@ -263,6 +267,7 @@ onMounted(() => {
         class="min-h-[200px]"
         @update:content="checkStates"
         @paste="isValidPasedText"
+        :placeholder="placeholder"
       >
         <template #toolbar>
           <div

--- a/packages/vue/src/Form/TextEditor/snow.css
+++ b/packages/vue/src/Form/TextEditor/snow.css
@@ -387,9 +387,8 @@
   text-align: right;
 }
 .ql-editor.ql-blank::before {
-  color: rgba(0, 0, 0, 0.6);
+  color: #9295A5;
   content: attr(data-placeholder);
-  font-style: italic;
   left: 15px;
   pointer-events: none;
   position: absolute;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a placeholder property to the text editor component, allowing users to see a default text prompt when the editor is empty.
- **Style**
	- Updated the placeholder text color and removed the italic style for better readability and consistency in design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->