### PR TITLE
Feature/hit 6867 | text editor add set text color and resize image

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.244",
+  "version": "0.5.246",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.244",
+      "version": "0.5.246",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.244",
+  "version": "0.5.246",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.stories.js
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.stories.js
@@ -43,13 +43,12 @@ export const Default = {
     setup() {
       const modelValue = ref("default model value");
       const onUpdateImage = (base64) => {
-        console.log(base64);
+        // console.log(base64);
       };
       return { args, modelValue, onUpdateImage };
     },
     template: `
           <Theme>
-          {{ modelValue}}
             <TextEditor id="quill-example" v-model="modelValue" v-bind="args" @update:image="onUpdateImage"/>
 
             <div class="flex gap-y-6 flex-col mt-8">Preview

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -256,6 +256,10 @@ const showImageWidthToolbar = ref(false);
 const updateImageWidth = (val) => {
   imageWidth.value = val;
   quill.value.getQuill().format("width", `${imageWidth.value}%`);
+  window
+    .getSelection()
+    ?.focusNode?.querySelector("img")
+    .setAttribute("style", "margin:auto;display:block");
 };
 
 const onClickContent = () => {

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -4,7 +4,7 @@ import { QuillEditor } from "./QuillEditor";
 import { ColorPicker } from "@/orchidui/ColorPicker.js";
 
 import { computed, onMounted, ref } from "vue";
-import { BaseInput, Icon, Dropdown } from "@/orchidui";
+import { BaseInput, Icon, Dropdown, Slider } from "@/orchidui";
 
 const props = defineProps({
   /**
@@ -164,6 +164,7 @@ const setLink = () => {
 const setBlockquote = () => {
   quill.value.getQuill().format("blockquote", !isBlockquoteActive.value);
 };
+
 const readImage = (base64) => {
   const range = quill.value.getQuill().getSelection();
   if (!range) return;
@@ -249,6 +250,13 @@ onMounted(() => {
   setSize(props.initialFontSize || props.fontSizes[0].value);
   loaded.value = true;
 });
+
+const imageWidth = ref(100);
+
+const updateImageWidth = (val) => {
+  imageWidth.value = val;
+  quill.value.getQuill().format("width", `${imageWidth.value}%`);
+};
 </script>
 
 <template>
@@ -262,7 +270,6 @@ onMounted(() => {
     :tooltip-options="tooltipOptions"
   >
     <div class="grid">
-      {{ colorPickModel }}
       <QuillEditor
         v-if="id"
         :id="`#${id}`"
@@ -447,15 +454,6 @@ onMounted(() => {
                 />
               </div>
             </template>
-
-            <div class="border-l border-oc-gray-200" />
-            <div class="flex gap-x-3 items-center">
-              <ColorPicker
-                v-model="colorPickModel"
-                hide-input-color
-                @update:model-value="setColor"
-              />
-            </div>
             <template v-if="toolbar.includes('alignment')">
               <div class="border-l border-oc-gray-200" />
 
@@ -506,6 +504,27 @@ onMounted(() => {
                 />
               </div>
             </template>
+
+            <div class="border-l border-oc-gray-200" />
+            <div class="flex gap-x-3 items-center">
+              <ColorPicker
+                v-model="colorPickModel"
+                hide-input-color
+                @update:model-value="setColor"
+              />
+            </div>
+            <div class="border-l border-oc-gray-200" />
+
+            <div class="flex gap-x-3 items-center">
+              <Slider
+                label="Image width"
+                class="w-[120px]"
+                :model-value="imageWidth"
+                :min-limit="0"
+                :max-limit="100"
+                @update:modelValue="updateImageWidth"
+              />
+            </div>
           </div>
         </template>
       </QuillEditor>

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -252,10 +252,15 @@ onMounted(() => {
 });
 
 const imageWidth = ref(100);
-
+const showImageWidthToolbar = ref(false);
 const updateImageWidth = (val) => {
   imageWidth.value = val;
   quill.value.getQuill().format("width", `${imageWidth.value}%`);
+};
+
+const onClickContent = () => {
+  let focusNode = window.getSelection()?.focusNode?.innerHTML;
+  showImageWidthToolbar.value = focusNode && focusNode.includes("<img");
 };
 </script>
 
@@ -269,7 +274,7 @@ const updateImageWidth = (val) => {
     :tooltip-text="tooltipText"
     :tooltip-options="tooltipOptions"
   >
-    <div class="grid">
+    <div class="grid" @click="onClickContent">
       <QuillEditor
         v-if="id"
         :id="`#${id}`"
@@ -515,7 +520,7 @@ const updateImageWidth = (val) => {
             </div>
             <div class="border-l border-oc-gray-200" />
 
-            <div class="flex gap-x-3 items-center">
+            <div v-if="showImageWidthToolbar" class="flex gap-x-3 items-center">
               <Slider
                 label="Image width"
                 class="w-[120px]"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to adjust image width in the text editor.
  - Introduced a toolbar for image width adjustment when images are detected in the content.

- **Improvements**
  - Updated version of the `@orchidui/vue` package to 0.5.246.

- **Code Quality**
  - Commented out a `console.log` statement in the text editor's story file to reduce unnecessary console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->