### PR TITLE
feature/add-tooltip-slot

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.271",
+  "version": "0.5.274",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.271",
+      "version": "0.5.274",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.271",
+  "version": "0.5.276",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/BaseInput/OcBaseInput.vue
+++ b/packages/vue/src/Form/BaseInput/OcBaseInput.vue
@@ -25,10 +25,12 @@ defineProps({
       </span>
       <Tooltip v-if="labelIcon" v-bind="tooltipOptions">
         <Icon width="16" height="16" :name="labelIcon" />
-        <template v-if="tooltipText" #popper>
-          <div class="px-3 py-2">
-            {{ tooltipText }}
-          </div>
+        <template #popper>
+            <slot name="tooltipText">
+              <div v-if="tooltipText" class="px-3 py-2">
+                {{ tooltipText }}
+              </div>
+            </slot>
         </template>
       </Tooltip>
     </label>

--- a/packages/vue/src/Form/Select/OcSelect.vue
+++ b/packages/vue/src/Form/Select/OcSelect.vue
@@ -400,5 +400,11 @@ defineExpose({
         </div>
       </template>
     </Dropdown>
+    <template #tooltipText>
+      <div v-if="$slots.selectTooltipText">
+        <slot name="selectTooltipText"></slot>
+      </div>
+
+    </template>
   </BaseInput>
 </template>


### PR DESCRIPTION
- add slots to tooltip in baseInput and select input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a tooltip functionality in form inputs and select components.
  
- **Updates**
  - Updated `@orchidui/vue` package version to 0.5.276.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->