### PR TITLE
Add isPopover prop

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.310",
+  "version": "0.5.311",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.310",
+      "version": "0.5.311",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.310",
+  "version": "0.5.311",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Overlay/Tooltip/OcTooltip.stories.js
+++ b/packages/vue/src/Overlay/Tooltip/OcTooltip.stories.js
@@ -59,7 +59,7 @@ export const Default = {
                 </template>
               </Tooltip>
               <Tooltip :key="args.trigger" :trigger="args.trigger" :distance="args.distance" :skidding="args.skidding"
-                       :position="args.position"
+                       :position="args.position" is-popover
                        popper-class="bg-oc-gray-900 text-oc-text-100">
                 <div class="p-3 rounded-sm cursor-pointer">Trigger</div>
                 <template #popper>

--- a/packages/vue/src/Overlay/Tooltip/OcTooltip.vue
+++ b/packages/vue/src/Overlay/Tooltip/OcTooltip.vue
@@ -50,11 +50,17 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  isPopover: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const isShow = ref(false);
 const triggerEl = ref();
+const popperBodyEl = ref();
 const popper = ref();
+
 const show = () => {
   isShow.value = true;
   // Update its position
@@ -76,9 +82,19 @@ onMounted(() => {
     hideEvents.forEach((event) => {
       triggerEl.value.addEventListener(event, hide);
     });
+
+    if (props.isPopover) {
+      showEvents.forEach((event) => {
+        popperBodyEl.value.addEventListener(event, show);
+      });
+
+      hideEvents.forEach((event) => {
+        popperBodyEl.value.addEventListener(event, hide);
+      });
+    }
   } else {
     triggerEl.value.addEventListener("click", () =>
-      isShow.value ? hide() : show()
+      isShow.value ? hide() : show(),
     );
   }
 });
@@ -101,7 +117,12 @@ const onClickOutside = () => {
       </div>
       <template #popper>
         <Transition :name="transitionName">
-          <div v-show="isShow" class="oc-tooltip" :class="popperClass">
+          <div
+            v-show="isShow"
+            ref="popperBodyEl"
+            class="oc-tooltip"
+            :class="popperClass"
+          >
             <slot name="popper" />
             <div v-if="!arrowHidden" class="oc-arrow" data-popper-arrow />
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `isPopover` attribute to the Tooltip component, allowing tooltips to be rendered as popovers.

- **Chores**
  - Updated `@orchidui/vue` package version to 0.5.311.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->