### PR TITLE
Bugfix Store Design | HIT-7751 , HIT-7700

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.311",
+  "version": "0.5.312",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.311",
+      "version": "0.5.312",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.313",
+  "version": "0.5.314",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.311",
+  "version": "0.5.312",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/ColorPicker/ColorPicker.vue
+++ b/packages/vue/src/Form/ColorPicker/ColorPicker.vue
@@ -106,7 +106,7 @@ const handleClickLastUsedColor = (color) => {
 <template>
   <BaseInput
     :class="hideInputColor ? 'w-[40px]' : ''"
-    @click.stop="() => dropdownRef?.toggleDropdown()"
+    @click="() => dropdownRef?.toggleDropdown()"
   >
     <Dropdown
       ref="dropdownRef"

--- a/packages/vue/src/Overlay/Modal/OcModal.stories.js
+++ b/packages/vue/src/Overlay/Modal/OcModal.stories.js
@@ -179,6 +179,9 @@ export const FormInModal = {
                 :values="values"
                 :json-form="JSON_FORM"
                 @onUpdate="onUpdateForm" />
+                <div class="h-[1000px]">
+                space area
+                </div>
               </Modal>
             </div>
           </Theme>

--- a/packages/vue/src/Overlay/Modal/OcModal.vue
+++ b/packages/vue/src/Overlay/Modal/OcModal.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Icon, Button } from "@/orchidui";
-import { computed } from "vue";
+import { computed, ref, watch, onUnmounted } from "vue";
 
 const props = defineProps({
   isBorderless: Boolean,
@@ -101,6 +101,20 @@ const sizeClasses = computed(() => ({
   medium: "max-w-[480px]",
   small: "max-w-[320px]",
 }));
+
+const scrollArea = ref()
+const  handleScroll = () => {
+  scrollArea.value?.click()
+}
+watch(() => props.modelValue, () => {
+  setTimeout(() => {
+    scrollArea.value?.addEventListener('scroll', handleScroll);
+  }, 100)
+})
+
+onUnmounted(() => {
+  scrollArea.value?.removeEventListener('scroll', handleScroll);
+})
 </script>
 
 <template>
@@ -115,12 +129,12 @@ const sizeClasses = computed(() => ({
     />
 
     <div
-      class="z-[1008] shadow-normal w-[calc(100%-40px)] max-h-[96vh] bg-oc-bg-light rounded-xl flex flex-col overflow-y-auto"
+      class="z-[1008] shadow-normal w-[calc(100%-40px)] max-h-[96vh] bg-oc-bg-light rounded-xl flex flex-col "
       :class="sizeClasses[size]"
     >
       <div
         v-if="isHeaderVisible"
-        class="flex border-oc-gray-200 gap-x-9 justify-between p-5 items-start"
+        class="flex bg-inherit border-oc-gray-200 gap-x-9 justify-between p-5 items-start z-[1011] rounded-t-xl"
         :class="!isBorderless ? 'border-b' : ''"
       >
         <slot name="header">
@@ -151,6 +165,8 @@ const sizeClasses = computed(() => ({
 
       <div
         :id="modalId"
+        ref="scrollArea"
+        class="overflow-y-auto"
         :class="[size === 'small' ? 'p-5' : 'p-7', isBorderless ? 'py-0' : '']"
       >
         <slot></slot>

--- a/packages/vue/src/Overlay/Popper/OcPopper.vue
+++ b/packages/vue/src/Overlay/Popper/OcPopper.vue
@@ -60,7 +60,7 @@ onMounted(() => {
   popperInstance.value = createPopper(
     reference.value,
     popper.value,
-    getPopperOptions(),
+    getPopperOptions()
   );
 
   // Need add setTimeout because placement is not updated immediately from props when component is mounted
@@ -73,7 +73,7 @@ watch(
     popperInstance.value.setOptions(getPopperOptions());
     popperInstance.value.update();
   },
-  { deep: true },
+  { deep: true }
 );
 </script>
 
@@ -86,7 +86,7 @@ watch(
       ref="popper"
       :class="popperClass"
       :style="popperStyle"
-      class="z-[1005]"
+      class="z-[1010]"
     >
       <slot name="popper" />
     </div>

--- a/packages/vue/src/Overlay/Tooltip/OcTooltip.vue
+++ b/packages/vue/src/Overlay/Tooltip/OcTooltip.vue
@@ -94,7 +94,7 @@ onMounted(() => {
     }
   } else {
     triggerEl.value.addEventListener("click", () =>
-      isShow.value ? hide() : show(),
+      isShow.value ? hide() : show()
     );
   }
 });
@@ -111,6 +111,7 @@ const onClickOutside = () => {
       :skidding="skidding"
       :distance="distance"
       :popper-options="popperOptions"
+      class="!z-[1010]"
     >
       <div ref="triggerEl" class="w-[inherit] relative">
         <slot />
@@ -137,7 +138,7 @@ const onClickOutside = () => {
   box-shadow:
     0 3px 22px 0 rgba(38, 42, 50, 0.09),
     0 1px 3px 0 rgba(0, 0, 0, 0.1);
-  @apply rounded-sm z-[1006];
+  @apply rounded-sm z-[1010];
 
   &-wrapper {
     div[data-popper-placement^="top"] .oc-arrow {


### PR DESCRIPTION
https://linear.app/hitpay/issue/HIT-7751/[store-design]-the-color-palette-tooltip-should-be-closed-when-open
https://linear.app/hitpay/issue/HIT-7700/openclose-sidebar-tooltip-is-overlapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scroll area and event handling logic to modal components for better user experience.

- **Improvements**
  - Updated z-index values for poppers and tooltips to ensure proper layering.
  - Enhanced tooltip event listeners for more reliable show/hide behavior.
  - Improved modal component with additional scroll handling and better styling.

- **Bug Fixes**
  - Corrected event handler in color picker to fix dropdown toggling issue.
  - Removed unnecessary commas in popper component to prevent potential issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->