### PR TITLE
Revert z index popper | bugfix

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.325",
+  "version": "0.5.326",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.325",
+      "version": "0.5.326",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.324",
+  "version": "0.5.325",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.324",
+      "version": "0.5.325",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.323",
+  "version": "0.5.324",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.323",
+      "version": "0.5.324",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.326",
+  "version": "0.5.327",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.326",
+      "version": "0.5.327",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.324",
+  "version": "0.5.325",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.326",
+  "version": "0.5.327",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.325",
+  "version": "0.5.326",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.323",
+  "version": "0.5.324",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/ColorPicker/components/GradientSettings.vue
+++ b/packages/vue/src/Form/ColorPicker/components/GradientSettings.vue
@@ -9,7 +9,7 @@
         @update:modelValue="handleInput($event, 'angle')"
       >
         <template #min-limit-label>0 </template>
-        <template #max-limit-label>100<span>&#176;</span></template>
+        <template #max-limit-label>360<span>&#176;</span></template>
       </Slider>
     </template>
 

--- a/packages/vue/src/Form/TextEditor/QuillEditor.js
+++ b/packages/vue/src/Form/TextEditor/QuillEditor.js
@@ -125,7 +125,7 @@ export const QuillEditor = defineComponent({
       (_a = quill.getModule("toolbar")) === null || _a === void 0
         ? void 0
         : _a.container.addEventListener("mousedown", (e) => {
-            if (e.target.getAttribute("class") === "picker-hue-range-slider") {
+            if (["picker-hue-range-slider","picker-opacity-slider"].includes(e.target.getAttribute("class"))) {
               // remove prevent default
             } else {
               e.preventDefault();

--- a/packages/vue/src/Overlay/Popper/OcPopper.vue
+++ b/packages/vue/src/Overlay/Popper/OcPopper.vue
@@ -86,7 +86,7 @@ watch(
       ref="popper"
       :class="popperClass"
       :style="popperStyle"
-      class="z-[1010]"
+      class="z-[1005]"
     >
       <slot name="popper" />
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the maximum limit label for the gradient slider from "100°" to "360°" in the ColorPicker module.

- **Style**
  - Adjusted the z-index value for better layering in overlay components.

- **Chores**
  - Updated the package version from "0.5.323" to "0.5.326".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->