### PR TITLE
update hex and opacity on keyup enter

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.332",
+  "version": "0.5.334",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.332",
+      "version": "0.5.334",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.332",
+  "version": "0.5.334",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/ColorPicker/components/input/InputHex.vue
+++ b/packages/vue/src/Form/ColorPicker/components/input/InputHex.vue
@@ -5,6 +5,7 @@
     :model-value="internal"
     @update:model-value="handleInput"
     @blur="emitModelValue"
+    @keyup.enter="emitModelValue"
   />
 </template>
 

--- a/packages/vue/src/Form/ColorPicker/components/input/InputOpacity.vue
+++ b/packages/vue/src/Form/ColorPicker/components/input/InputOpacity.vue
@@ -5,6 +5,7 @@
     :model-value="internal"
     @update:model-value="handleInput"
     @blur="emitModelValue"
+    @keyup.enter="emitModelValue"
   >
     <template #leading>%</template></Input
   >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to the ColorPicker component to trigger actions when the Enter key is pressed in both the hex input and opacity input fields.

- **Chores**
  - Updated the version of the `@orchidui/vue` package from "0.5.332" to "0.5.334".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->