### PR TITLE
Add isTransparent prop to List Item

### DIFF
--- a/packages/vue/src/DataDisplay/ListItem/OcListItem.vue
+++ b/packages/vue/src/DataDisplay/ListItem/OcListItem.vue
@@ -37,6 +37,7 @@ const props = defineProps({
     default: () => [],
   },
   isDisabled: Boolean,
+  isTransparent: Boolean,
 });
 defineEmits(["more", "edit", "delete", "click:item"]);
 

--- a/packages/vue/src/DataDisplay/ListItem/components/OcGeneral.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcGeneral.vue
@@ -19,6 +19,7 @@ defineProps({
     type: Boolean,
     default: true,
   },
+  isTransparent: Boolean,
 });
 const emit = defineEmits(["more"]);
 const isOpen = ref(false);
@@ -32,7 +33,10 @@ const toggleDashboard = () => {
 <template>
   <div
     class="px-5 py-4 rounded border border-gray-200 group"
-    :class="{ 'hover:shadow-normal': !isDisabled }"
+    :class="{
+      'hover:shadow-normal': !isDisabled && !isTransparent,
+      'border-none !p-0': isTransparent,
+    }"
     @mouseleave="isOpen = false"
   >
     <div class="flex items-center gap-x-4 w-full">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `isTransparent` option to list items, allowing users to set the transparency of list items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->