### PR TITLE
Add preset colors

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.361",
+  "version": "0.5.362",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.361",
+      "version": "0.5.362",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.361",
+  "version": "0.5.362",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/ColorPicker/ColorPicker.vue
+++ b/packages/vue/src/Form/ColorPicker/ColorPicker.vue
@@ -15,7 +15,10 @@ const props = defineProps({
     default: 'solid'
   },
   hideOpacity: Boolean,
-  hideInputColor: Boolean
+  hideInputColor: Boolean,
+  presetColors: {
+    type: Array
+  }
 })
 
 const emit = defineEmits(['update:model-value'])
@@ -96,7 +99,12 @@ const handleClickLastUsedColor = (color) => {
 
 <template>
   <BaseInput :class="hideInputColor ? 'w-[40px]' : ''" @click="() => dropdownRef?.toggleDropdown()">
-    <Dropdown ref="dropdownRef" v-model="isOpen" @update:model-value="onCloseDropdown">
+    <Dropdown
+      ref="dropdownRef"
+      v-model="isOpen"
+      @update:model-value="onCloseDropdown"
+      max-menu-height="auto"
+    >
       <Input
         v-if="!hideInputColor"
         :model-value="inputValue"
@@ -122,6 +130,7 @@ const handleClickLastUsedColor = (color) => {
           :type="hideOpacity ? 'HEX' : 'HEX8'"
           :model-value="modelValue"
           :last-used-colors="localColorList"
+          :preset-colors="presetColors"
           @update:model-value="onUpdate"
           @last-used-pick="handleClickLastUsedColor"
         />

--- a/packages/vue/src/Form/ColorPicker/components/VueColorPicker.vue
+++ b/packages/vue/src/Form/ColorPicker/components/VueColorPicker.vue
@@ -34,7 +34,20 @@
         @onInput="setGradientBarColor"
       />
     </div>
-    <div v-else class="mb-5"></div>
+    <div v-else :class="{ 'mb-5': !presetColors }">
+      <div v-if="presetColors">
+        <div class="text-oc-text-400 text-sm my-3 font-medium">Choose color</div>
+        <div class="ck-cp-local-color-conatiner">
+          <div
+            v-for="color in presetColors"
+            :key="`color-${color}`"
+            class="ck-cp-color-item !w-[32px] !h-[32px]"
+            :style="`background:${color}`"
+            @click="handleColorItemOnClick(color)"
+          ></div>
+        </div>
+      </div>
+    </div>
     <PickerWrap @onMouseDown="handlePickerStartOnMouseDown" />
 
     <div class="flex items-center gap-2">
@@ -89,7 +102,7 @@
         <InputOpacity v-if="showAlpha" v-model="opacity" @update:model-value="setOpacity($event)" />
       </div>
     </div>
-    <div class="text-oc-text-400 text-sm my-3">Last used</div>
+    <div class="text-oc-text-400 text-sm my-3 font-medium font-inter">Last used</div>
     <div v-if="localColorList.length > 0 && showColorList" class="ck-cp-local-color-conatiner">
       <div
         v-for="color in localColorListFiltered"
@@ -159,6 +172,7 @@ const props = defineProps({
     },
     type: Object
   },
+  presetColors: Array,
   variant: {
     type: String,
     default: 'solid'
@@ -1211,7 +1225,7 @@ onMounted(() => {
 
 .ck-cp-container * {
   outline: none;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-family: Inter, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .ck-cp-controller-bar {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `presetColors` to the ColorPicker component, allowing users to select from an array of preset colors.

- **Style**
  - Updated the text style for the "Last used" section in the ColorPicker.
  - Applied a new CSS font-family rule using the Inter font.

- **Chores**
  - Updated the package version from "0.5.361" to "0.5.362".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->