### PR TITLE
Add chip props table

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.365",
+  "version": "0.5.366",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.365",
+      "version": "0.5.366",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.20.1"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.365",
+  "version": "0.5.366",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Builder/DataTable/OcDataTable.stories.js
+++ b/packages/vue/src/Builder/DataTable/OcDataTable.stories.js
@@ -123,9 +123,6 @@ export const Default = {
               <template #col4="{ data }">
                 <span class="text-oc-text-400 text-sm">{{ data }}</span>
               </template>
-              <template #col5="{ data }">
-                <Chip variant="success" class="w-fit" :label="data"/>
-              </template>
               <template #col6="{ data }">
                 <div class="flex gap-3 items-center">
                   <Toggle size="small" v-model="data"/>

--- a/packages/vue/src/DataDisplay/Table/OcTableCell.vue
+++ b/packages/vue/src/DataDisplay/Table/OcTableCell.vue
@@ -61,6 +61,22 @@ const hasContentData = computed(() => {
   return props.data || props.content.title || props.content.description
 })
 
+const chipProps = computed(() => {
+  const options = props.chipOptions[props.data]
+
+  if (typeof options === 'object') {
+    return {
+      label: options.label || props.data,
+      ...options
+    }
+  }
+
+  return {
+    label: props.data,
+    variant: options
+  }
+})
+
 const variantClass = computed(() => ({
   [Variants.CHECKBOX]: 'md:px-2 px-4 min-w-[32px]',
   [Variants.ICON]: 'md:px-2 px-4 min-w-[32px] ',
@@ -134,7 +150,7 @@ const variantClass = computed(() => ({
         <TableCellContent v-else-if="variant === Variants.CONTENT" v-bind="content" :link="link" />
         <TableLink v-else-if="variant === Variants.CHIP" :link="link">
           <!--   CHIP   -->
-          <Chip :label="data" :variant="chipOptions[data]" />
+          <Chip v-bind="chipProps" />
         </TableLink>
 
         <!--  DEFAULT    -->

--- a/packages/vue/src/data/DataTableOptions.sample.js
+++ b/packages/vue/src/data/DataTableOptions.sample.js
@@ -73,7 +73,15 @@ const DataTableOptions = {
       {
         key: 'col5',
         label: 'Table Header',
-        class: 'w-1/2 md:w-[15%]'
+        class: 'w-1/2 md:w-[15%]',
+        variant: 'chip',
+        chipOptions: {
+          Label: {
+            label: 'Label',
+            variant: 'success',
+            icon: 'check'
+          }
+        }
       },
       {
         key: 'col6',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `chipProps` property in `OcTableCell` for enhanced chip configuration based on `chipOptions`.

- **Bug Fixes**
  - Updated `DataTableOptions` with a new `variant` and `chipOptions` configuration for better customization.

- **Improvements**
  - Removed chip component rendering in the data table to streamline the visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->