### PR TITLE
[HIT-8627] Making select to fit on input's trailing section

### DIFF
--- a/packages/vue/src/Form/Input/OcInput.stories.js
+++ b/packages/vue/src/Form/Input/OcInput.stories.js
@@ -322,7 +322,6 @@ export const Trailing = {
                     is-transparent
                     is-slim
                     @click.stop
-                    @keydown.stop
                     @update:model-value="updateSelectedCurrency"
                   />
                 </template>
@@ -337,7 +336,6 @@ export const Trailing = {
                     is-transparent
                     is-slim
                     @click.stop
-                    @keydown.stop
                     @update:model-value="updateSelectedCurrency"
                   />
                 </template>
@@ -353,7 +351,6 @@ export const Trailing = {
                     is-transparent
                     is-slim
                     @click.stop
-                    @keydown.stop
                     @update:model-value="updateSelectedCurrency"
                   />
                 </template>

--- a/packages/vue/src/Form/Input/OcInput.stories.js
+++ b/packages/vue/src/Form/Input/OcInput.stories.js
@@ -6,6 +6,7 @@ import Icon from '../../MediaAndIcons/Icon/OcIcon.vue'
 import { ref } from 'vue'
 import BaseInput from '../BaseInput/OcBaseInput.vue'
 import { InputOption } from '@/orchidui'
+import { Select } from '@/orchidui'
 
 export default {
   component: OCInput,
@@ -154,11 +155,158 @@ export const MainComponent = {
 
 export const Trailing = {
   render: () => ({
-    components: { Theme, OCInput, Dropdown, DropdownItem, Icon },
+    components: { Theme, OCInput, Select },
     setup() {
       const isDropdownOpen = ref([])
+      const selectedCurrency = ref('sgd')
+      const currencies = [
+        { "label": "Any amount", "value": "any" },
+        { "value": "aed", "label": "AED" },
+        { "value": "all", "label": "ALL" },
+        { "value": "amd", "label": "AMD" },
+        { "value": "ang", "label": "ANG" },
+        { "value": "aoa", "label": "AOA" },
+        { "value": "ars", "label": "ARS" },
+        { "value": "aud", "label": "AUD" },
+        { "value": "awg", "label": "AWG" },
+        { "value": "azn", "label": "AZN" },
+        { "value": "bam", "label": "BAM" },
+        { "value": "bbd", "label": "BBD" },
+        { "value": "bdt", "label": "BDT" },
+        { "value": "bgn", "label": "BGN" },
+        { "value": "bif", "label": "BIF" },
+        { "value": "bmd", "label": "BMD" },
+        { "value": "bnd", "label": "BND" },
+        { "value": "bob", "label": "BOB" },
+        { "value": "brl", "label": "BRL" },
+        { "value": "bsd", "label": "BSD" },
+        { "value": "bwp", "label": "BWP" },
+        { "value": "bzd", "label": "BZD" },
+        { "value": "cad", "label": "CAD" },
+        { "value": "cdf", "label": "CDF" },
+        { "value": "chf", "label": "CHF" },
+        { "value": "clp", "label": "CLP" },
+        { "value": "cny", "label": "CNY" },
+        { "value": "cop", "label": "COP" },
+        { "value": "crc", "label": "CRC" },
+        { "value": "cve", "label": "CVE" },
+        { "value": "czk", "label": "CZK" },
+        { "value": "djf", "label": "DJF" },
+        { "value": "dkk", "label": "DKK" },
+        { "value": "dop", "label": "DOP" },
+        { "value": "dzd", "label": "DZD" },
+        { "value": "egp", "label": "EGP" },
+        { "value": "etb", "label": "ETB" },
+        { "value": "eur", "label": "EUR" },
+        { "value": "fjd", "label": "FJD" },
+        { "value": "fkp", "label": "FKP" },
+        { "value": "gbp", "label": "GBP" },
+        { "value": "gel", "label": "GEL" },
+        { "value": "gip", "label": "GIP" },
+        { "value": "gmd", "label": "GMD" },
+        { "value": "gnf", "label": "GNF" },
+        { "value": "gtq", "label": "GTQ" },
+        { "value": "gyd", "label": "GYD" },
+        { "value": "hkd", "label": "HKD" },
+        { "value": "hnl", "label": "HNL" },
+        { "value": "hrk", "label": "HRK" },
+        { "value": "htg", "label": "HTG" },
+        { "value": "huf", "label": "HUF" },
+        { "value": "idr", "label": "IDR" },
+        { "value": "ils", "label": "ILS" },
+        { "value": "inr", "label": "INR" },
+        { "value": "isk", "label": "ISK" },
+        { "value": "jmd", "label": "JMD" },
+        { "value": "kes", "label": "KES" },
+        { "value": "kgs", "label": "KGS" },
+        { "value": "khr", "label": "KHR" },
+        { "value": "kmf", "label": "KMF" },
+        { "value": "krw", "label": "KRW" },
+        { "value": "kyd", "label": "KYD" },
+        { "value": "kzt", "label": "KZT" },
+        { "value": "lak", "label": "LAK" },
+        { "value": "lbp", "label": "LBP" },
+        { "value": "lkr", "label": "LKR" },
+        { "value": "lrd", "label": "LRD" },
+        { "value": "lsl", "label": "LSL" },
+        { "value": "mad", "label": "MAD" },
+        { "value": "mdl", "label": "MDL" },
+        { "value": "mga", "label": "MGA" },
+        { "value": "mkd", "label": "MKD" },
+        { "value": "mmk", "label": "MMK" },
+        { "value": "mnt", "label": "MNT" },
+        { "value": "mop", "label": "MOP" },
+        { "value": "mro", "label": "MRO" },
+        { "value": "mur", "label": "MUR" },
+        { "value": "mvr", "label": "MVR" },
+        { "value": "mwk", "label": "MWK" },
+        { "value": "mxn", "label": "MXN" },
+        { "value": "myr", "label": "MYR" },
+        { "value": "mzn", "label": "MZN" },
+        { "value": "nad", "label": "NAD" },
+        { "value": "ngn", "label": "NGN" },
+        { "value": "nio", "label": "NIO" },
+        { "value": "nok", "label": "NOK" },
+        { "value": "npr", "label": "NPR" },
+        { "value": "nzd", "label": "NZD" },
+        { "value": "pab", "label": "PAB" },
+        { "value": "pen", "label": "PEN" },
+        { "value": "pgk", "label": "PGK" },
+        { "value": "php", "label": "PHP" },
+        { "value": "pkr", "label": "PKR" },
+        { "value": "pln", "label": "PLN" },
+        { "value": "pyg", "label": "PYG" },
+        { "value": "qar", "label": "QAR" },
+        { "value": "ron", "label": "RON" },
+        { "value": "rsd", "label": "RSD" },
+        { "value": "rub", "label": "RUB" },
+        { "value": "rwf", "label": "RWF" },
+        { "value": "sar", "label": "SAR" },
+        { "value": "sbd", "label": "SBD" },
+        { "value": "scr", "label": "SCR" },
+        { "value": "sek", "label": "SEK" },
+        { "value": "sgd", "label": "SGD" },
+        { "value": "shp", "label": "SHP" },
+        { "value": "sll", "label": "SLL" },
+        { "value": "sos", "label": "SOS" },
+        { "value": "srd", "label": "SRD" },
+        { "value": "std", "label": "STD" },
+        { "value": "szl", "label": "SZL" },
+        { "value": "thb", "label": "THB" },
+        { "value": "tjs", "label": "TJS" },
+        { "value": "top", "label": "TOP" },
+        { "value": "try", "label": "TRY" },
+        { "value": "ttd", "label": "TTD" },
+        { "value": "twd", "label": "TWD" },
+        { "value": "tzs", "label": "TZS" },
+        { "value": "uah", "label": "UAH" },
+        { "value": "ugx", "label": "UGX" },
+        { "value": "usd", "label": "USD" },
+        { "value": "uyu", "label": "UYU" },
+        { "value": "uzs", "label": "UZS" },
+        { "value": "vnd", "label": "VND" },
+        { "value": "vuv", "label": "VUV" },
+        { "value": "wst", "label": "WST" },
+        { "value": "xaf", "label": "XAF" },
+        { "value": "xcd", "label": "XCD" },
+        { "value": "xof", "label": "XOF" },
+        { "value": "xpf", "label": "XPF" },
+        { "value": "yer", "label": "YER" },
+        { "value": "zar", "label": "ZAR" },
+        { "value": "zmw", "label": "ZMW" }
+      ]
+
+      const updateSelectedCurrency = (currency) => {
+        selectedCurrency.value = currencies.find(
+          (currentCurrency) => currentCurrency.value === currency
+        ).value
+      }
+
       return {
-        isDropdownOpen
+        isDropdownOpen,
+        selectedCurrency,
+        currencies,
+        updateSelectedCurrency
       }
     },
     template: `
@@ -166,60 +314,48 @@ export const Trailing = {
             <div class="flex items-end gap-x-4">
               <OCInput label="Label" hint="This is a hint text to help user">
                 <template #trailing>
-                  <Dropdown v-model="isDropdownOpen[1]">
-                    <template #menu>
-                      <div class="flex p-2 flex-col">
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[1]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[1]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[1]=false"/>
-                      </div>
-                    </template>
-                    <div
-                        class=" text-sm font-medium flex items-center gap-x-2 text-oc-text-400"
-                    >
-                      <span class="flex items-center text-sm">USD</span>
-                      <Icon class="w-[14px] h-[14px]" name="chevron-down"/>
-                    </div>
-                  </Dropdown>
+                  <Select
+                    :key="selectedCurrency"
+                    :model-value="selectedCurrency"
+                    :options="currencies"
+                    is-filterable
+                    is-transparent
+                    is-slim
+                    @click.stop
+                    @keydown.stop
+                    @update:model-value="updateSelectedCurrency"
+                  />
                 </template>
               </OCInput>
               <OCInput disabled label="Label" hint="This is a hint text to help user">
                 <template #trailing>
-                  <Dropdown v-model="isDropdownOpen[2]">
-                    <template #menu>
-                      <div class="flex p-2 flex-col">
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[2]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[2]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[2]=false"/>
-                      </div>
-                    </template>
-                    <div
-                        class=" text-sm font-medium flex items-center gap-x-2 text-oc-text-400"
-                    >
-                      <span class="flex items-center text-sm">USD</span>
-                      <Icon class="w-[14px] h-[14px]" name="chevron-down"/>
-                    </div>
-                  </Dropdown>
+                  <Select
+                    :key="selectedCurrency"
+                    :model-value="selectedCurrency"
+                    :options="currencies"
+                    is-filterable
+                    is-transparent
+                    is-slim
+                    @click.stop
+                    @keydown.stop
+                    @update:model-value="updateSelectedCurrency"
+                  />
                 </template>
               </OCInput>
               <OCInput label="Label" hint="This is a hint text to help user"
                        error-message="Error message">
                 <template #trailing>
-                  <Dropdown v-model="isDropdownOpen[3]">
-                    <template #menu>
-                      <div class="flex p-2 flex-col">
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[3]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[3]=false"/>
-                        <DropdownItem text="Menu" icon="pencil" @click="isDropdownOpen[3]=false"/>
-                      </div>
-                    </template>
-                    <div
-                        class=" text-sm font-medium flex items-center gap-x-2 text-oc-text-400"
-                    >
-                      <span class="flex items-center text-sm">USD</span>
-                      <Icon class="w-[14px] h-[14px]" name="chevron-down"/>
-                    </div>
-                  </Dropdown>
+                  <Select
+                    :key="selectedCurrency"
+                    :model-value="selectedCurrency"
+                    :options="currencies"
+                    is-filterable
+                    is-transparent
+                    is-slim
+                    @click.stop
+                    @keydown.stop
+                    @update:model-value="updateSelectedCurrency"
+                  />
                 </template>
               </OCInput>
             </div>

--- a/packages/vue/src/Form/Select/OcSelect.stories.js
+++ b/packages/vue/src/Form/Select/OcSelect.stories.js
@@ -106,6 +106,7 @@ export const Default = {
     isCheckboxes: false,
     isSelectAll: false,
     isTransparent: false,
+    isSlim: false,
     labelIcon: '',
     tooltipText: 'Tooltip text',
     tooltipOptions: {

--- a/packages/vue/src/Form/Select/OcSelect.vue
+++ b/packages/vue/src/Form/Select/OcSelect.vue
@@ -20,6 +20,7 @@ const props = defineProps({
   isSelectAll: Boolean,
   isAddNew: Boolean,
   isTransparent: Boolean,
+  isSlim: Boolean,
   hideChevron: Boolean,
   options: Array,
   modelValue: [Array, String, Number],
@@ -263,6 +264,9 @@ defineExpose({
       ref="dropdownRef"
       v-model="isDropdownOpened"
       class="w-full bg-white"
+      :class="{
+        '!bg-transparent': isTransparent,
+      }"
       :distance="4"
       popper-class="w-full"
       placement="bottom-end"
@@ -277,7 +281,8 @@ defineExpose({
           'border-oc-error': errorMessage && !isDisabled,
           'pointer-events-none bg-oc-bg-dark': isDisabled,
           'py-3': multiple,
-          'border-none !min-h-[30px] px-0': isTransparent
+          'border-none !min-h-[30px] px-0': isTransparent,
+          'border-none !min-h-[18px] !px-0': isSlim
         }"
       >
         <div v-if="multiple" class="flex flex-wrap gap-2 overflow-hidden">


### PR DESCRIPTION
To make currencies to be filterable, OcSelect should fit well on OcInput's trailing section. This is not happening because OcSelect's current min-height (30px) overflows trailing section height + padding (check image bellow).

To fix that issue, I added a new prop called `isSlim` to set OcSelect min-height to 18px and remove all paddings.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/8dafa3fe-67a8-4ca7-b1bd-dafb4416ee9e)|![image](https://github.com/user-attachments/assets/99b5f187-6efd-4fd9-9737-00a6e5522c51)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Select` component for currency selection, improving user interaction and experience.
	- Added a `slim` variant option to the `Select` component for enhanced visual flexibility.
  
- **Improvements**
	- Enhanced styling options based on new properties, allowing for a more customizable UI experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->