### PR TITLE
Add banner component

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.412",
+  "version": "0.5.413",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.412",
+      "version": "0.5.413",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.412",
+  "version": "0.5.413",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Feedback/Banner/OcBanner.js
+++ b/packages/vue/src/Feedback/Banner/OcBanner.js
@@ -1,0 +1,3 @@
+import Banner from './OcBanner.vue'
+
+export { Banner }

--- a/packages/vue/src/Feedback/Banner/OcBanner.stories.js
+++ b/packages/vue/src/Feedback/Banner/OcBanner.stories.js
@@ -1,0 +1,70 @@
+import { Theme, Banner } from '@/orchidui'
+
+export default {
+  component: Banner,
+  tags: ['autodocs']
+}
+
+export const Default = {
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['default', 'primary', 'error', 'warning', 'gray'],
+      default: 'default'
+    },
+    icon: {
+      control: 'select',
+      options: ['filled-check', 'circle', 'plus', 'x'],
+      default: 'filled-check'
+    }
+  },
+  args: {
+    modelValue: true,
+    showIcon: true,
+    transitionName: 'slide-from-top',
+    icon: 'filled-check',
+    color: 'default',
+    content: 'Changes have been successfully saved',
+    title: 'Title',
+    dismissible: true
+  },
+  render: (args) => ({
+    components: { Banner, Theme },
+    setup() {
+      return { args }
+    },
+    template: `
+          <Theme colorMode="light" class="h-[300px]">
+            <div class="flex flex-col gap-y-4">
+              <Banner v-bind="args" v-model="args.modelValue"/>
+            </div>
+          </Theme>
+        `
+  })
+}
+
+export const Variants = {
+  args: {
+    showIcon: true,
+    icon: 'filled-check',
+    content: 'Changes have been successfully saved',
+    title: 'Title'
+  },
+  render: (args) => ({
+    components: { Banner, Theme },
+    setup() {
+      return { args }
+    },
+    template: `
+          <Theme colorMode="light">
+            <div class="flex flex-col gap-y-4">
+              <Banner v-bind="args"/>
+              <Banner v-bind="args" color="primary"/>
+              <Banner v-bind="args" color="error"/>
+              <Banner v-bind="args" color="warning"/>
+              <Banner v-bind="args" color="gray"/>
+            </div>
+          </Theme>
+        `
+  })
+}

--- a/packages/vue/src/Feedback/Banner/OcBanner.vue
+++ b/packages/vue/src/Feedback/Banner/OcBanner.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { Icon, Button } from '@/orchidui'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: true
+  },
+  color: {
+    type: String,
+    default: 'default'
+  },
+  content: {
+    type: String,
+    default: ''
+  },
+  icon: {
+    type: String,
+    default: 'filled-check'
+  },
+  showIcon: {
+    type: Boolean,
+    default: true
+  },
+  dismissible: {
+    type: Boolean,
+    default: false
+  },
+  transitionName: {
+    type: String,
+    default: 'slide-from-top'
+  },
+  title: {
+    type: String,
+    default: ''
+  }
+})
+defineEmits(['update:modelValue'])
+const colorClasses = Object.freeze({
+  default: 'bg-oc-success-50 text-oc-success-500',
+  primary: 'bg-oc-primary-50 text-oc-primary-500',
+  error: 'bg-oc-error-50 text-oc-error-500',
+  warning: 'bg-oc-warning-50 text-oc-warning-500',
+  gray: 'bg-oc-gray-100 text-oc-gray-700'
+})
+const borderClasses = Object.freeze({
+  default: 'border-oc-success-200',
+  primary: 'border-oc-primary-200',
+  error: 'border-oc-error-200',
+  warning: 'border-oc-warning-200',
+  gray: 'border-oc-gray-300'
+})
+</script>
+
+<template>
+  <Transition :name="transitionName">
+    <div
+      v-show="modelValue"
+      :class="borderClasses[color]"
+      class="border rounded-lg banner relative overflow-hidden"
+    >
+      <div
+        class="flex flex-1 items-center justify-between gap-3 min-h-[34px] px-4 text-sm"
+        :class="colorClasses[color]"
+      >
+        <div class="flex items-center gap-3">
+          <Icon v-if="showIcon" :name="icon" class="shrink-0" width="16" height="16" />
+
+          <slot name="title">
+            <div class="text-oc-text-500">{{ title }}</div>
+          </slot>
+        </div>
+
+        <Button
+          v-if="dismissible"
+          variant="secondary"
+          is-transparent
+          label="Close"
+          @click="$emit('update:modelValue', false)"
+        />
+      </div>
+
+      <div class="p-4 text-sm">
+        <slot>
+          {{ content }}
+        </slot>
+      </div>
+    </div>
+  </Transition>
+</template>
+<style lang="scss" scoped>
+.banner {
+  transition:
+    transform 0.5s,
+    opacity 0.5s;
+}
+
+.slide-from-top-enter-from {
+  transform: translateY(-200%);
+}
+
+.slide-from-top-enter-to {
+  transform: translateY(0%);
+}
+
+.slide-from-top-leave-from {
+  opacity: 1;
+}
+
+.slide-from-top-leave-to {
+  opacity: 0;
+}
+</style>

--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -34,6 +34,7 @@ export * from './Elements/OnboardingProgressbar/OcOnboardingProgressbar.js'
 
 export * from './Feedback/Chip/OcChip.js'
 export * from './Feedback/Snackbar/OcSnackbar.js'
+export * from './Feedback/Banner/OcBanner.js'
 export * from './Feedback/ShareIcon/OcShareIcon.js'
 export * from './Feedback/Tag/OcTag.js'
 


### PR DESCRIPTION

<img width="943" alt="image" src="https://github.com/user-attachments/assets/e6ad0a12-e1bf-47d3-9be1-4ca7b3e64d40">


https://www.figma.com/design/rgEPwO5cYueowG05qbw9JI/Store-Design?node-id=4332-15286&m=dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new customizable `OcBanner` component for displaying notifications.
	- Added Storybook stories for the `Banner` component, showcasing default and variant configurations.

- **Bug Fixes**
	- Version increment for the `@orchidui/vue` package to improve stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->