### PR TITLE
Fix color picker width

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.426",
+  "version": "0.5.427",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/ColorPicker/components/VueColorPicker.vue
+++ b/packages/vue/src/Form/ColorPicker/components/VueColorPicker.vue
@@ -1212,7 +1212,7 @@ onMounted(() => {
   background-color: var(--cp-container-bg);
   border-radius: 1rem;
   padding: 10px;
-  width: 352px;
+  width: 360px;
   height: auto;
 }
 


### PR DESCRIPTION
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/c07a78df-33a8-40ad-bc44-3aa0f92cebf6)|![image](https://github.com/user-attachments/assets/6b58f31d-7d99-49b9-b69c-142634d488a0)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@orchidui/vue` package to version `0.5.427`, including minor improvements and bug fixes.
  
- **Style**
	- Adjusted the width of the container in the `VueColorPicker` component for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->