### PR TITLE
Added slot between table and pagination

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.435",
+  "version": "0.5.436",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.435",
+      "version": "0.5.436",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.435",
+  "version": "0.5.436",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Builder/DataTable/OcDataTable.vue
+++ b/packages/vue/src/Builder/DataTable/OcDataTable.vue
@@ -453,6 +453,7 @@ const displayFilterData = computed(() => {
         <slot name="table-body" v-bind="slotProps"></slot>
       </template>
     </Table>
+    <slot name="before-pagination"></slot>
     <div
       v-if="paginationOption || cursorOption"
       class="flex gap-3 items-center"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Incremented the version number of the `@orchidui/vue` package, indicating a new release with potential enhancements and fixes.
	- Introduced a new `before-pagination` slot in the `OcDataTable` component, allowing for enhanced customization before pagination controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->