### PR TITLE
Add chips to accordion item list type

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.440",
+  "version": "0.5.441",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.440",
+      "version": "0.5.441",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.440",
+  "version": "0.5.441",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
+++ b/packages/vue/src/DataDisplay/ListItem/OcListItem.stories.js
@@ -333,7 +333,12 @@ export const ListItemAccordion = {
     description: 'Strawberry, Chocolate, and Cheese',
     isDisabled: false,
     isTransparent: false,
-    isDraggable: true
+    isDraggable: true,
+    chips: [
+      {
+        label: 'Required'
+      }
+    ]
   },
   render: (args) => ({
     components: { Theme, ListItem },

--- a/packages/vue/src/DataDisplay/ListItem/components/OcAccordion.vue
+++ b/packages/vue/src/DataDisplay/ListItem/components/OcAccordion.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { Icon } from '@/orchidui'
+import { Chip, Icon } from '@/orchidui'
 import { ref } from 'vue'
 
 defineProps({
   title: String,
   description: String,
+  chips: {
+    type: Array,
+    default: () => []
+  },
   isDisabled: Boolean,
   isTransparent: Boolean,
   isDraggable: Boolean
@@ -44,6 +48,18 @@ const toggleAccordion = () => {
               <span v-if="title" class="text-base text-oc-text font-medium truncate">
                 {{ title }}
               </span>
+
+              <div v-if="chips.length" class="flex gap-3 shrink-0">
+                <Chip
+                  v-for="(item, i) in chips"
+                  :key="i"
+                  :label="item.label"
+                  :variant="item.variant"
+                  :icon="item.icon"
+                  :icon-tooltip="item.iconTooltip"
+                  class="font-medium shrink-0"
+                />
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@orchidui/vue` package to version `0.5.441`, which may include minor enhancements and bug fixes.
	- Introduced a new `chips` property in the `ListItemAccordion`, enabling the display of additional contextual information through chip elements in the accordion component.

- **Enhancements**
	- Enhanced the `OcAccordion` component to support the new `chips` property, improving visual representation and interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->