### PR TITLE
Add is replace image to cropper

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.445",
+  "version": "0.5.446",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.445",
+      "version": "0.5.446",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.445",
+  "version": "0.5.446",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/Cropper/OcCropper.stories.js
+++ b/packages/vue/src/Form/Cropper/OcCropper.stories.js
@@ -10,7 +10,8 @@ export const Default = {
     link: '',
     label: '',
     withLink: false,
-    img: '/images/image.jpg'
+    img: '/images/image.jpg',
+    isReplaceImage: true
   },
   render: (args) => ({
     components: { Cropper, Theme },
@@ -30,6 +31,7 @@ export const Default = {
                 :link="args.link"
                 :img="args.img"
                 :max-size="args.maxSize"
+                :is-replace-image="args.isReplaceImage"
                 @change-image="args.image = $event"
                 @update:link="args.link = $event"
             />

--- a/packages/vue/src/Form/Cropper/OcCropper.vue
+++ b/packages/vue/src/Form/Cropper/OcCropper.vue
@@ -8,12 +8,15 @@ const props = defineProps({
   withLink: Boolean,
   link: String,
   img: String,
-  maxSize: [String, Number]
+  maxSize: [String, Number],
+  isReplaceImage: {
+    type: Boolean,
+    default: true
+  }
 })
 const emit = defineEmits(['changeImage', 'update:link'])
 const cropper = ref()
 const fileUploadEl = ref()
-const imageEl = ref()
 
 const localImage = ref('')
 const imageChanged = ref(false)
@@ -75,7 +78,14 @@ const defaultSize = ({ imageSize, visibleArea }) => {
 
 <template>
   <div class="flex flex-col gap-y-5">
-    <input ref="fileUploadEl" accept="image/*" type="file" class="hidden" @change="fileUpload" />
+    <input
+      id="cropper-file-input"
+      ref="fileUploadEl"
+      accept="image/*"
+      type="file"
+      class="hidden"
+      @change="fileUpload"
+    />
 
     <Cropper
       v-if="localImage"
@@ -97,6 +107,7 @@ const defaultSize = ({ imageSize, visibleArea }) => {
         <Button variant="secondary" size="small" left-icon="forward" @click="rotate(90)" />
       </template>
       <Button
+        v-if="isReplaceImage"
         class="absolute right-0"
         variant="secondary"
         size="small"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `isReplaceImage` in the image cropping component, allowing users to control the display of the image replacement button.
	- Enhanced accessibility by adding an `id` attribute to the file upload input element.

- **Version Update**
	- Updated the version of the `@orchidui/vue` package to 0.5.446, indicating a minor update with improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->