### PR TITLE
Add attach to body option for Popper

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.448",
+  "version": "0.5.449",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.448",
+      "version": "0.5.449",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.448",
+  "version": "0.5.449",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Builder/DataTable/OcDataTable.vue
+++ b/packages/vue/src/Builder/DataTable/OcDataTable.vue
@@ -394,6 +394,7 @@ const displayFilterData = computed(() => {
                 v-model="isDropdownOpened"
                 :distance="9"
                 placement="bottom-end"
+                is-attach-to-body
               >
                 <Button :is-active="isDropdownOpened" variant="secondary" left-icon="filter" />
 

--- a/packages/vue/src/Overlay/Dropdown/OcDropdown.vue
+++ b/packages/vue/src/Overlay/Dropdown/OcDropdown.vue
@@ -32,7 +32,8 @@ const props = defineProps({
   popperStyle: Object,
   popperClass: [String, Array, Object],
   modelValue: Boolean,
-  preventClickOutside: Boolean
+  preventClickOutside: Boolean,
+  isAttachToBody: Boolean
 })
 const popper = ref()
 const dropdownScroll = ref()
@@ -84,6 +85,7 @@ defineExpose({
       :skidding="skidding"
       :popper-style="popperStyle"
       :popper-options="popperOptions"
+      :is-attach-to-body="isAttachToBody"
     >
       <div class="w-[inherit] flex" @click="toggleDropdown">
         <slot />

--- a/packages/vue/src/Overlay/Popper/OcPopper.vue
+++ b/packages/vue/src/Overlay/Popper/OcPopper.vue
@@ -37,6 +37,10 @@ const props = defineProps({
   popperClass: {
     type: [String, Array, Object],
     default: ''
+  },
+  isAttachToBody: {
+    type: Boolean,
+    default: false
   }
 })
 const getPopperOptions = () => ({
@@ -78,8 +82,10 @@ watch(
     <div ref="reference" class="w-[inherit] flex">
       <slot />
     </div>
-    <div ref="popper" :class="popperClass" :style="popperStyle" class="z-[1005]">
-      <slot name="popper" />
-    </div>
+    <teleport to="body" :disabled="!isAttachToBody">
+      <div ref="popper" :class="popperClass" :style="popperStyle" class="z-[1005]">
+        <slot name="popper" />
+      </div>
+    </teleport>
   </div>
 </template>

--- a/packages/vue/src/data/DataTableOptions.sample.js
+++ b/packages/vue/src/data/DataTableOptions.sample.js
@@ -34,6 +34,7 @@ const DataTableOptions = {
     form: SampleFilterForm
   },
   tableOptions: {
+    isSticky: false,
     isSelectable: true,
     isCursorPointer: true,
     isBorderless: false,


### PR DESCRIPTION
For fix this issue https://app.birdeatsbug.com/lOgkOend0A1Kon-LMXX6IG6VNBDGeXxdnmGliDhkG8rY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the `is-attach-to-body` attribute for dropdown components, improving positioning and usability.
	- Added the `isAttachToBody` prop to dropdown and popper components for enhanced rendering flexibility.
	- Introduced a new `isSticky` property in table options for improved table display control.
	- Incremented the version number of the package to reflect recent updates.

- **Bug Fixes**
	- Enhanced dropdown and popper behavior to ensure proper attachment and visibility management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->