### PR TITLE
Fix additional area icon

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.488",
+  "version": "0.5.489",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.488",
+      "version": "0.5.489",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.488",
+  "version": "0.5.489",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/Button/OcButton.vue
+++ b/packages/vue/src/Form/Button/OcButton.vue
@@ -27,9 +27,9 @@ defineEmits(['addition-click'])
 const isPressed = ref(false)
 const isIconOnly = computed(() => (props.leftIcon || props.rightIcon) && !props.label)
 const additionalAreaSize = computed(() => ({
-  default: 'w-10 h-[36px]',
+  default: 'w-10',
   small: 'w-9 h-8',
-  big: 'w-[48px] h-[44px]'
+  big: 'w-[48px]'
 }))
 
 const shadowContainer = computed(() => ({


### PR DESCRIPTION
<img width="167" alt="image" src="https://github.com/user-attachments/assets/f5df3fc0-04de-405e-a84a-4156c03bbfd8">
<br/>

[https://linear.app/hitpay/issue/HIT-9954/[invoice]-the-create-button-should-be-same-as-figma](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `@orchidui/vue` package to 0.5.489.
  
- **Style**
	- Enhanced layout and styling of the `OcButton` component for improved appearance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->