### PR TITLE
[Chore] Option: Sublabel slot

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.498",
+  "version": "0.5.500",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/Select/OcOption.vue
+++ b/packages/vue/src/Form/Select/OcOption.vue
@@ -45,7 +45,9 @@ defineExpose({
 
         <div class="flex flex-col gap-3 overflow-hidden" :class="{ 'flex-1': isCheckboxes }">
           <span class="truncate">{{ label }}</span>
-          <span v-if="subLabel" class="text-sm text-oc-text-300">{{ subLabel }}</span>
+          <slot name="sub-label">
+            <span v-if="subLabel" class="text-sm text-oc-text-300">{{ subLabel }}</span>
+          </slot>
         </div>
 
         <slot name="leading"></slot>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable `<slot>` for the `subLabel` in the `OcOption` component, allowing users to insert custom content.
  
- **Version Updates**
	- Updated the version of the `@orchidui/vue` package from `0.5.498` to `0.5.500`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->