### PR TITLE
New box style for checkboxes and radios

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.513",
+  "version": "0.5.520",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.513",
+      "version": "0.5.520",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.519",
+  "version": "0.5.520",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/Checkbox/OcCheckbox.vue
+++ b/packages/vue/src/Form/Checkbox/OcCheckbox.vue
@@ -9,7 +9,8 @@ const props = defineProps({
   label: String,
   topLabel: String,
   hint: String,
-  errorMessage: String
+  errorMessage: String,
+  isButtonVariant: Boolean
 })
 const emit = defineEmits({
   'update:modelValue': []
@@ -38,9 +39,17 @@ const onInput = () => emit('update:modelValue', !props.isDisabled ? !props.model
 
 <template>
   <BaseInput class="w-fit" :label="topLabel" :hint="hint" :error-message="errorMessage">
-    <label class="flex items-center gap-x-3 cursor-pointer">
+    <label
+      class="flex items-center gap-x-3 cursor-pointer"
+      :class="{
+        '!border-oc-error': errorMessage && isButtonVariant,
+        'border-gray-200 border py-5 px-6 rounded cursor-pointer transition-all duration-300 !gap-x-4':
+          isButtonVariant,
+        'border-oc-primary-500': modelValue
+      }"
+    >
       <div
-        class="w-5 h-5 shrink-0 border flex items-center justify-center rounded-sm"
+        class="w-5 h-5 shrink-0 border flex items-center justify-center rounded-sm transition-all duration-300"
         :class="computedClasses"
       >
         <Icon
@@ -57,7 +66,7 @@ const onInput = () => emit('update:modelValue', !props.isDisabled ? !props.model
         />
       </div>
 
-      <span v-if="label" class="text-sm">{{ label }}</span>
+      <span v-if="label" :class="{ 'text-sm': !isButtonVariant }">{{ label }}</span>
       <input
         :value="modelValue"
         type="checkbox"

--- a/packages/vue/src/Form/CheckboxesGroup/OcCheckboxesGroup.stories.js
+++ b/packages/vue/src/Form/CheckboxesGroup/OcCheckboxesGroup.stories.js
@@ -68,7 +68,7 @@ export const Default = {
         `
   })
 }
-export const Variants = {
+export const buttonVariants = {
   args: {
     label: 'Label',
     checkboxes: [
@@ -97,21 +97,27 @@ export const Variants = {
   render: (args) => ({
     components: { CheckboxesGroup, Theme },
     setup() {
-      return { args }
+      const selectedCheckbox1 = ref([])
+      const selectedCheckbox2 = ref([])
+
+      return { selectedCheckbox1, selectedCheckbox2, args }
     },
     template: `
           <Theme>
             <div class="flex flex-col gap-y-4">
               <CheckboxesGroup
+                  v-model="selectedCheckbox1"
                   :checkboxes="args.checkboxes"
                   :label="args.label"
                   alignment="vertical"
-
+                  is-button-variant
               />
               <CheckboxesGroup
+                  v-model="selectedCheckbox2"
                   :checkboxes="args.checkboxes"
                   :label="args.label"
                   alignment="horizontal"
+                  is-button-variant
               />
             </div>
           </Theme>

--- a/packages/vue/src/Form/CheckboxesGroup/OcCheckboxesGroup.vue
+++ b/packages/vue/src/Form/CheckboxesGroup/OcCheckboxesGroup.vue
@@ -15,7 +15,9 @@ const props = defineProps({
   errorMessage: String,
   hint: String,
   isDisabled: Boolean,
-  isSelectAll: Boolean
+  isSelectAll: Boolean,
+  isButtonVariant: Boolean,
+  isBlock: Boolean
 })
 const emit = defineEmits({
   'update:modelValue': []
@@ -56,6 +58,7 @@ const selectAll = () => {
         :is-disabled="isDisabled"
         :value="allCheckboxValues"
         :model-value="isAllSelected"
+        :is-button-variant="isButtonVariant"
         @update:model-value="selectAll"
       />
       <Checkbox
@@ -65,8 +68,9 @@ const selectAll = () => {
         :value="checkbox.value"
         :is-error="!!errorMessage"
         :is-disabled="isDisabled"
-        class="!w-fit"
+        :class="{ '!w-fit': !isBlock }"
         :model-value="isSelectedCheckbox(checkbox.value)"
+        :is-button-variant="isButtonVariant"
         @update:model-value="toggleCheckbox(checkbox.value)"
       />
     </div>

--- a/packages/vue/src/Form/Radio/OcRadio.vue
+++ b/packages/vue/src/Form/Radio/OcRadio.vue
@@ -48,7 +48,7 @@ defineEmits({
         'bg-gray-200': isDisabled && isButtonVariant,
         '!border-oc-error': errorMessage && isButtonVariant,
         'radio-button__label--button border-gray-200 border py-3 px-5 rounded': isButtonVariant,
-        '!px-6 !py-5': isButtonVariantWithRadio
+        '!px-6 !py-5 !gap-x-4': isButtonVariantWithRadio
       }"
     >
       <span

--- a/packages/vue/src/Form/Radio/OcRadio.vue
+++ b/packages/vue/src/Form/Radio/OcRadio.vue
@@ -14,6 +14,7 @@ defineProps({
   labelIcon: String,
   tooltipOptions: Object,
   isButtonVariant: Boolean,
+  isButtonVariantWithRadio: Boolean,
   icon: String
 })
 defineEmits({
@@ -46,11 +47,12 @@ defineEmits({
         '!text-oc-text-300': isDisabled,
         'bg-gray-200': isDisabled && isButtonVariant,
         '!border-oc-error': errorMessage && isButtonVariant,
-        'radio-button__label--button border-gray-200 border py-3 px-5 rounded': isButtonVariant
+        'radio-button__label--button border-gray-200 border py-3 px-5 rounded': isButtonVariant,
+        '!px-6 !py-5': isButtonVariantWithRadio
       }"
     >
       <span
-        v-if="!isButtonVariant"
+        v-if="!isButtonVariant || isButtonVariantWithRadio"
         class="radio-button__custom w-5 h-5 rounded-full border transition-all duration-300"
         :class="[
           isDisabled || !modelValue ? 'border-oc-primary-200 bg-oc-primary-50' : '',
@@ -66,22 +68,20 @@ defineEmits({
       />
 
       <slot>
-        <span v-if="label" class="text-sm">{{ label }}</span>
+        <span v-if="label" :class="{ 'text-sm': !isButtonVariantWithRadio }">{{ label }}</span>
       </slot>
 
       <Tooltip v-if="labelIcon" v-bind="tooltipOptions">
-      <Icon width="16" height="16" :name="labelIcon" class="text-oc-text-400" />
-      <template #popper>
+        <Icon width="16" height="16" :name="labelIcon" class="text-oc-text-400" />
+        <template #popper>
           <slot name="tooltipText">
             <div v-if="tooltipText" class="px-3 py-2 whitespace-nowrap">
               {{ tooltipText }}
             </div>
-        </slot>
-      </template>
-    </Tooltip>
+          </slot>
+        </template>
+      </Tooltip>
     </label>
-
- 
   </BaseInput>
 </template>
 

--- a/packages/vue/src/Form/RadioGroup/OcRadioGroup.stories.js
+++ b/packages/vue/src/Form/RadioGroup/OcRadioGroup.stories.js
@@ -186,3 +186,62 @@ export const buttonVariants = {
     `
   })
 }
+
+export const buttonVariantsWithRadio = {
+  args: {
+    radio: [
+      {
+        label: 'Text',
+        value: 6
+      },
+      {
+        label: 'Text',
+        value: 7
+      },
+      {
+        label: 'Text',
+        value: 8
+      },
+      {
+        label: 'Text',
+        value: 9
+      },
+      {
+        label: 'Text',
+        value: 10
+      }
+    ]
+  },
+  render: (args) => ({
+    components: { RadioGroup, Theme },
+    setup() {
+      const selectedRadio1 = ref()
+      const selectedRadio2 = ref()
+      return { selectedRadio1, selectedRadio2, args }
+    },
+    template: `
+      <Theme>
+        <div class="flex flex-col gap-y-4">
+          <RadioGroup
+            v-model="selectedRadio1"
+            :radio="args.radio"
+            label="Label"
+            group-name="radio3"
+            alignment="vertical"
+            :is-button-variant="true"
+            :is-button-variant-with-radio="true"
+          />
+          <RadioGroup
+            v-model="selectedRadio2"
+            :radio="args.radio"
+            label="Label"
+            group-name="radio4"
+            alignment="horizontal"
+            :is-button-variant="true"
+            :is-button-variant-with-radio="true"
+          />
+        </div>
+      </Theme>
+    `
+  })
+}

--- a/packages/vue/src/Form/RadioGroup/OcRadioGroup.vue
+++ b/packages/vue/src/Form/RadioGroup/OcRadioGroup.vue
@@ -15,7 +15,8 @@ defineProps({
   hint: String,
   modelValue: String,
   isButtonVariant: Boolean,
-  isButtonVariantWithRadio: Boolean
+  isButtonVariantWithRadio: Boolean,
+  isBlock: Boolean
 })
 const emit = defineEmits({
   'update:modelValue': []
@@ -36,7 +37,7 @@ const onInput = (value) => {
         v-for="(item, i) in radio"
         :id="item.value"
         :key="i"
-        class="!w-fit"
+        :class="{ '!w-fit': !isBlock }"
         :model-value="item.value"
         :label="item.label"
         :icon="item.icon"

--- a/packages/vue/src/Form/RadioGroup/OcRadioGroup.vue
+++ b/packages/vue/src/Form/RadioGroup/OcRadioGroup.vue
@@ -14,7 +14,8 @@ defineProps({
   errorMessage: String,
   hint: String,
   modelValue: String,
-  isButtonVariant: Boolean
+  isButtonVariant: Boolean,
+  isButtonVariantWithRadio: Boolean
 })
 const emit = defineEmits({
   'update:modelValue': []
@@ -47,6 +48,7 @@ const onInput = (value) => {
         :label-icon="item.labelIcon"
         :tooltip-options="item.tooltipOptions"
         :is-button-variant="isButtonVariant"
+        :is-button-variant-with-radio="isButtonVariantWithRadio"
         @update:model-value="onInput"
       />
     </div>


### PR DESCRIPTION
<img width="584" alt="image" src="https://github.com/user-attachments/assets/9988afbc-007d-4e54-865b-af67051fdcfb">

<img width="598" alt="image" src="https://github.com/user-attachments/assets/79b383d9-fe9f-4f1c-a289-2c90c201faae">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `isButtonVariant` and `isBlock` properties to `OcCheckboxesGroup` and `OcRadioGroup`, enhancing styling options.
  - Added `isButtonVariantWithRadio` to `OcRadio`, allowing for button variant styling.
  - New story `buttonVariantsWithRadio` added to demonstrate the new radio button options.

- **Improvements**
  - Enhanced `OcCheckbox` and `OcCheckboxesGroup` components for better flexibility in styling and behavior.
  - Updated story configurations for `OcCheckboxesGroup` to support more checkbox options. 

- **Version Update**
  - Updated `@orchidui/vue` package version from `0.5.519` to `0.5.520`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->