### PR TITLE
feature/HIT-10596 add divider to TextEditor

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.520",
+  "version": "0.5.522",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.520",
+      "version": "0.5.522",
       "license": "MIT"
     }
   }

--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchidui/vue",
-  "version": "0.5.522",
+  "version": "0.5.523",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchidui/vue",
-      "version": "0.5.522",
+      "version": "0.5.523",
       "license": "MIT"
     }
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.522",
+  "version": "0.5.523",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.520",
+  "version": "0.5.522",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -561,7 +561,7 @@ const onClickContent = () => {
                 />
               </div>
             </div>
-            <div class="mt-1 mx-2">
+            <div class="mt-1 mx-2 cursor-pointer">
               <svg
                 width="20"
                 height="20"

--- a/packages/vue/src/Form/TextEditor/OcTextEditor.vue
+++ b/packages/vue/src/Form/TextEditor/OcTextEditor.vue
@@ -89,6 +89,25 @@ Quill.register(DirectionStyle, true)
 const FontStyle = Quill.import('attributors/style/font')
 Quill.register(FontStyle, true)
 
+const BlockEmbed = Quill.import('blots/block/embed')
+
+class DividerBlot extends BlockEmbed {
+  static blotName = 'divider'
+  static tagName = 'hr'
+}
+
+Quill.register(DividerBlot)
+
+const addDivider = () => {
+  const index = quill.value.getQuill().getSelection(true)
+  if (index) {
+    const range = quill.value.getQuill().getSelection(true)
+    quill.value.getQuill().insertText(range.index, '\n', Quill.sources.USER)
+    quill.value.getQuill().insertEmbed(range.index + 1, 'divider', true, Quill.sources.USER)
+    quill.value.getQuill().setSelection(range.index + 2, Quill.sources.SILENT)
+  }
+}
+
 const id = ref(
   Math.random()
     .toString(36)
@@ -494,7 +513,6 @@ const onClickContent = () => {
                 />
               </div>
             </template>
-
             <div class="border-l border-oc-gray-200" />
             <div class="flex items-center">
               <ColorPicker v-model="colorPickModel" hide-input-color @update:model-value="setColor">
@@ -510,7 +528,6 @@ const onClickContent = () => {
               </ColorPicker>
             </div>
             <div class="border-l border-oc-gray-200" />
-
             <div v-if="showImageWidthToolbar" class="flex gap-x-3 items-center px-5">
               <Slider
                 label="Image width"
@@ -543,6 +560,23 @@ const onClickContent = () => {
                   @click="setImageAlign('right')"
                 />
               </div>
+            </div>
+            <div class="mt-1 mx-2">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 15 15"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                @click="addDivider()"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M2 7.5C2 7.22386 2.22386 7 2.5 7H12.5C12.7761 7 13 7.22386 13 7.5C13 7.77614 12.7761 8 12.5 8H2.5C2.22386 8 2 7.77614 2 7.5Z"
+                  fill="#000000"
+                />
+              </svg>
             </div>
           </div>
         </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `Divider` feature in the text editor, allowing users to insert horizontal dividers easily.
	- Added a new SVG icon in the toolbar to trigger the divider insertion.
- **Style**
	- Minor adjustments made to the toolbar layout and styling for visual consistency.
- **Chores**
	- Updated the package version from `0.5.520` to `0.5.523`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->