### PR TITLE
[HIT-10632] feat: added localStorage saving for table by table-id (required prop)

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.525",
+  "version": "0.5.526",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Builder/DataTable/OcDataTable.vue
+++ b/packages/vue/src/Builder/DataTable/OcDataTable.vue
@@ -201,6 +201,19 @@ const changePage = () => {
   applyFilter(null, currentPage.value)
 }
 
+const saveFilterInLocalStorage = () => {
+  if (filterOptions.value?.columnEdit?.localStorageKey) {
+    setInLocalStorage(props.id, JSON.stringify(filterData.value))
+  }
+}
+
+const getFilterFromLocalStorage = () => {
+  if (props.id) {
+    return getFromLocalStorage(props.id)
+  }
+  return null
+}
+
 const applyFilter = (filterForm = null, isChangePage = false, changeCursor = '') => {
   if (paginationOption.value && !isChangePage) {
     currentPage.value = 1
@@ -233,6 +246,7 @@ const applyFilter = (filterForm = null, isChangePage = false, changeCursor = '')
       }
     })
   }
+  saveFilterInLocalStorage()
   emit('update:filter', filterData.value)
 }
 
@@ -384,6 +398,12 @@ const setOrderedHeaders = () => {
 
 onMounted(() => {
   setOrderedHeaders()
+  const filterFromLocalStorage = getFilterFromLocalStorage()
+  if (filterFromLocalStorage) {
+    filterData.value = JSON.parse(filterFromLocalStorage)
+    filterTab.value = filterTab.value || filterData.value?.tabs || filterData.value?.[filterOptions.value?.tabs?.key]
+    applyFilter()
+  }
 })
 </script>
 <template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced local storage functionality for filters in the `OcDataTable` component, allowing users to save and retrieve filter settings.
  - Filters are now automatically restored upon component initialization, enhancing user experience by maintaining context.

- **Chores**
  - Updated the version of the `@orchidui/vue` package from `0.5.525` to `0.5.526`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->