### PR TITLE
fix: fixed removing tabs filter

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/vue",
   "description": "Orchid UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "0.5.528",
+  "version": "0.5.529",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/vue/src/Builder/DataTable/OcDataTable.vue
+++ b/packages/vue/src/Builder/DataTable/OcDataTable.vue
@@ -251,6 +251,9 @@ const applyFilter = (filterForm = null, isChangePage = false, changeCursor = '')
 }
 
 const removeFilter = (filter, field) => {
+  if (filter === filterOptions.value.tabs.key || filter === 'tabs') {
+    filterTab.value = ''
+  }
   applyFilter(filter)
   emit('filter-removed', field)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved filter removal functionality in the DataTable component, ensuring the filter tab state is cleared when relevant filters are removed.
  
- **Chores**
	- Updated the version of the `@orchidui/vue` package from `0.5.528` to `0.5.529`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->