### PR TITLE
Feat: Added table meta-click

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.1.31-2",
+  "version": "1.1.31-3",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataDisplay/Table/OcTable.vue
+++ b/packages/core/src/DataDisplay/Table/OcTable.vue
@@ -36,7 +36,8 @@ const props = defineProps({
 const emit = defineEmits({
   'click:row': [],
   'update:selected': [],
-  'hover:cell': []
+  'hover:cell': [],
+  'click:row-meta': []
 })
 
 const isSelectable = computed(() => props.options.isSelectable)
@@ -87,8 +88,17 @@ const calculateRowClass = computed(() => {
   return () => props.rowClass
 })
 
-const onClickRow = (field, header) => {
+const onClickRow = (field, header, event) => {
+  
   if (!header.disableClickRow && header.key !== 'actions') {
+
+  if(event.metaKey) {
+    emit('click:row-meta', {
+        field: field,
+        header: header
+      })
+      return
+    }
     emit('click:row', {
       field: field,
       header: header
@@ -270,7 +280,7 @@ onMounted(() => onScroll())
               ]"
               :image-class="header.imageClass"
               :link="rowLink && field[rowLink] ? field[rowLink] : ''"
-              @click="onClickRow(field, header)"
+              @click="onClickRow(field, header, $event)"
               @hover:field="$emit('hover:cell', $event)"
             >
               <template #default>

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -57,7 +57,8 @@ const emit = defineEmits({
   'filter-fields-changed': [],
   'filter-removed': [],
   'search-query-changed': [],
-  'hover:cell': []
+  'hover:cell': [],
+  'click:row-meta': []
 })
 
 const paginationOption = computed(() => props.options?.pagination)
@@ -427,6 +428,7 @@ onMounted(() => {
       :is-borderless="tableOptions.isBorderless"
       @update:selected="$emit('update:selected', $event)"
       @click:row="$emit('click:row', $event)"
+      @click:row-meta="$emit('click:row-meta', $event)"
       @hover:cell="$emit('hover:cell', $event)"
     >
       <template

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.1.31-2",
+  "version": "1.1.31-3",
   "type": "module",
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new event `click:row-meta` in the `OcTable` and `OcDataTable` components, enhancing interactivity when clicking rows with the meta key.
  
- **Chores**
  - Updated version numbers for the `@orchidui/core` and `@orchidui/dashboard` packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->