### PR TITLE
fix: reverted table meta emit

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.1.31-4",
+  "version": "1.1.31-5",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataDisplay/Table/OcTable.vue
+++ b/packages/core/src/DataDisplay/Table/OcTable.vue
@@ -37,7 +37,6 @@ const emit = defineEmits({
   'click:row': [],
   'update:selected': [],
   'hover:cell': [],
-  'click:row-meta': []
 })
 
 const isSelectable = computed(() => props.options.isSelectable)
@@ -88,17 +87,9 @@ const calculateRowClass = computed(() => {
   return () => props.rowClass
 })
 
-const onClickRow = (field, header, event) => {
+const onClickRow = (field, header) => {
   
   if (!header.disableClickRow && header.key !== 'actions') {
-
-  if(event.metaKey) {
-    emit('click:row-meta', {
-        field: field,
-        header: header
-      })
-      return
-    }
     emit('click:row', {
       field: field,
       header: header
@@ -280,7 +271,7 @@ onMounted(() => onScroll())
               ]"
               :image-class="header.imageClass"
               :link="rowLink && field[rowLink] ? field[rowLink] : ''"
-              @click="onClickRow(field, header, $event)"
+              @click="onClickRow(field, header)"
               @hover:field="$emit('hover:cell', $event)"
             >
               <template #default>

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -58,7 +58,6 @@ const emit = defineEmits({
   'filter-removed': [],
   'search-query-changed': [],
   'hover:cell': [],
-  'click:row-meta': []
 })
 
 const paginationOption = computed(() => props.options?.pagination)
@@ -428,7 +427,6 @@ onMounted(() => {
       :is-borderless="tableOptions.isBorderless"
       @update:selected="$emit('update:selected', $event)"
       @click:row="$emit('click:row', $event)"
-      @click:row-meta="$emit('click:row-meta', $event)"
       @hover:cell="$emit('hover:cell', $event)"
     >
       <template

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.1.31-4",
+  "version": "1.1.31-5",
   "type": "module",
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
  - Updated version for `@orchidui/core` package from 1.1.31-4 to 1.1.31-5
  - Updated version for `@orchidui/dashboard` package from 1.1.31-4 to 1.1.31-5

- **Component Changes**
  - Removed `click:row-meta` event from `OcTable` and `OcDataTable` components
  - Simplified row click handling in table components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->