### PR TITLE
fix: removed bg from header, fixed warnings

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.6.1-14",
+  "version": "1.6.1-15",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Elements/Header/OcHeader.vue
+++ b/packages/core/src/Elements/Header/OcHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-oc-bg pr-9 pl-7 h-[55px] w-full flex"
+    class="pr-9 pl-7 h-[55px] w-full flex"
   >
     <slot />
   </div>

--- a/packages/core/src/Elements/Header/OcTabToSelect.vue
+++ b/packages/core/src/Elements/Header/OcTabToSelect.vue
@@ -44,15 +44,15 @@ onMounted(() => changeCurrentPosition())
     >
       <Icon
         :name="`header-icons/${item.icon}`"
-        width="24"
-        height="24"
+        :width="24"
+        :height="24"
         class="group-hover:block"
         :class="item.value === modelValue ? 'block' : 'hidden'"
       />
       <Icon
         :name="`header-icons/${item.icon}-gray`"
-        width="24"
-        height="24"
+        :width="24"
+        :height="24"
         class="group-hover:hidden"
         :class="item.value === modelValue ? 'hidden' : 'block'"
       />

--- a/packages/core/src/Elements/Sidebar/OcSidebarMenu.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebarMenu.vue
@@ -1,6 +1,6 @@
 <template>
  <div v-click-outside="onClickOutside"  class="relative" >
-  <Tooltip position="right" :arrow-hidden="isExpanded" :distance="10" :popper-options="{ strategy: 'fixed' }" class="w-full" >
+  <Tooltip position="right" arrow-hidden :distance="10" :popper-options="{ strategy: 'fixed' }" class="w-full" >
     <div
     ref="menuItemRef"
     class="py-2 px-3 z gap-x-3 flex items-center rounded hover:bg-[var(--oc-sidebar-menu-active)]"
@@ -11,8 +11,8 @@
   >
     <Icon
       :name="icon"
-      width="18"
-      height="18"
+      :width="18"
+      :height="18"
       :class="{ 
         'text-[var(--oc-sidebar-menu-active-icon-active)]': isActive,
         'text-[var(--oc-sidebar-menu-active-icon)]': !isActive,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.6.1-14",
+  "version": "1.6.1-15",
   "type": "module",
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Updated version number for `@orchidui/core` package from 1.6.1-14 to 1.6.1-15
	- Updated version number for `@orchidui/dashboard` package from 1.6.1-14 to 1.6.1-15

- **Style Changes**
	- Removed `bg-oc-bg` class from `OcHeader` component
	- Updated attribute bindings in `OcTabToSelect` and `OcSidebarMenu` components for `Icon` and `Tooltip` elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->