### PR TITLE
feat(OcSelect): Add default empty state slot for no data scenario

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.8.1-23",
+  "version": "1.8.1-24",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Form/Select/OcSelect.vue
+++ b/packages/core/src/Form/Select/OcSelect.vue
@@ -443,6 +443,12 @@ defineExpose({
                 "
                 @click="selectOption(option)"
               />
+              <!-- Empty div to trigger the slot -->
+              <slot name="empty">
+                <div v-if="!filterableOptions.length" class="text-sm text-oc-text-300  text-center">
+                  No data to display
+                </div>
+              </slot>
             </slot>
             <slot name="infinite-scrolling"></slot>
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.8.1-23",
+  "version": "1.8.1-24",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.stories.js
+++ b/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.stories.js
@@ -41,7 +41,7 @@ export const Default = {
   render: (args) => ({
     components: { TextEditor, Theme },
     setup() {
-      const modelValue = ref('default model value')
+      const modelValue = ref('')
       const onUpdateImage = () => {
         // console.log(base64);
       }
@@ -49,6 +49,10 @@ export const Default = {
     },
     template: `
           <Theme>
+
+            <div @click="modelValue = ''">Clear</div>
+            <div @click="modelValue = 'default model value'">Reset</div>
+
             <TextEditor id="quill-example" v-model="modelValue" v-bind="args" @update:image="onUpdateImage"/>
 
             <div class="flex gap-y-6 flex-col mt-8">Preview

--- a/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.vue
+++ b/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.vue
@@ -121,6 +121,7 @@ const loaded = ref(false)
 const base64Images = ref(props.image)
 
 const checkStates = (value) => {
+  console.log(value, 123);
   
   isUndoActive.value = quill.value.getQuill().history.stack.undo.length > 0
   isRedoActive.value = quill.value.getQuill().history.stack.redo.length > 0
@@ -341,7 +342,7 @@ const insertTable = () => {
 
 watch(() => props.modelValue, (val) => {
   if(!val) {
-    quill.value.getQuill().setContents([])
+    quill.value.getQuill().setContents([], 'silent')
   }
 })
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an empty state for the dropdown component to display a message (“No data to display”) when no options are available.
	- Added "Clear" and "Reset" buttons in the text editor for improved user interaction.

- **Chores**
	- Updated version numbers for both core and dashboard packages to version 1.8.1-24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->