### PR TITLE
chore: bump package versions to 1.8.1-39 for core and dashboard

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.8.1-33",
+  "version": "1.8.1-34",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -439,7 +439,6 @@ const setOrderedHeaders = () => {
 
 const changeSearchKey = (value) => {
   filterOptions.value.search.selectedOption = value
-  applyFilter()
 }
 
 onMounted(() => {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.8.1-33",
+  "version": "1.8.1-34",
   "type": "module",
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated version numbers across core and dashboard components to 1.8.1-39.

- **Refactor**
  - Adjusted the table view's search behavior so that entering a new search term no longer triggers an immediate filter update. Users may now need to confirm or trigger the filtering action separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->