### PR TITLE
[Select]: Add ability to compare not only primitive data types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9962,21 +9962,22 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.21.1-40",
+      "version": "1.21.1-41",
       "license": "MIT"
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.21.1-40",
+      "version": "1.21.1-41",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "beta"
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.21.1-39",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.21.1-39.tgz",
-      "integrity": "sha512-IV4yAjHQf6P3OjmkARBE+/tYNpclPq8htKsGntgrNVMNBOBrvKvZUDdXVyW3I4kS/3/+MBupmWfjXLA3b6RWEA=="
+      "version": "1.21.1-40",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.21.1-40.tgz",
+      "integrity": "sha512-v9aqALJOXYHb1Kh3tD7wpx2PIewV3fLBEmW/+ef4RU7N5JWFKCXbnk+lyh2rc0ZnWxbYRUHVlfs668hOBo53IA==",
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9962,21 +9962,22 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.21.1-39",
+      "version": "1.21.1-40",
       "license": "MIT"
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.21.1-39",
+      "version": "1.21.1-40",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "beta"
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.21.1-38",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.21.1-38.tgz",
-      "integrity": "sha512-FLzqgOlFO8U4jtley7oU16RWovaZXxT9+vvdAM+B2pcfKLTSWcYmiW2qVeiHCkvozF0vPpKK2TyngeY9PGY8Rw=="
+      "version": "1.21.1-39",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.21.1-39.tgz",
+      "integrity": "sha512-IV4yAjHQf6P3OjmkARBE+/tYNpclPq8htKsGntgrNVMNBOBrvKvZUDdXVyW3I4kS/3/+MBupmWfjXLA3b6RWEA==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.21.1-39",
+  "version": "1.21.1-40",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.21.1-40",
+  "version": "1.21.1-41",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Form/Select/OcSelect.vue
+++ b/packages/core/src/Form/Select/OcSelect.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { BaseInput, Button, Chip, Dropdown, Icon, Input, Option, Skeleton } from '@/orchidui-core'
 import { computed, nextTick, ref, watch } from 'vue'
+import { deepEqual } from './utils/deepEqual'
 
 const props = defineProps({
   label: String,
@@ -136,12 +137,12 @@ const localValueOption = computed(() => {
         for (const option of props.options) {
           if (option.values) {
             option.values.forEach((o) => {
-              if (o.value === value) {
+              if (deepEqual(o.value, value)) {
                 selected.push(o)
               }
             })
           } else {
-            if (option.value === value) {
+            if (deepEqual(option.value, value)) {
               selected.push(option)
             }
           }
@@ -150,7 +151,7 @@ const localValueOption = computed(() => {
     }
     return selected
   } else {
-    return props.options.find((o) => o.value?.toString() === props.modelValue?.toString())
+    return props.options.find((o) => deepEqual(o.value, props.modelValue))
   }
 })
 
@@ -162,7 +163,7 @@ const selectOption = (option) => {
   let result
 
   if (props.multiple) {
-    const isOptionHasBeenSelected = (props.modelValue || []).find((o) => o === option.value)
+    const isOptionHasBeenSelected = (props.modelValue || []).find((o) => deepEqual(o, option.value))
 
     if (
       !isOptionHasBeenSelected &&
@@ -175,7 +176,7 @@ const selectOption = (option) => {
     }
 
     result = isOptionHasBeenSelected
-      ? (props.modelValue || []).filter((o) => o !== option.value)
+      ? (props.modelValue || []).filter((o) => !deepEqual(o, option.value))
       : [...(props.modelValue || []), option.value]
   } else {
     result = option.value
@@ -188,7 +189,7 @@ const selectOption = (option) => {
 const removeOption = (value) => {
   emit(
     'update:modelValue',
-    (props.modelValue || []).filter((o) => o !== value)
+    (props.modelValue || []).filter((o) => !deepEqual(o, value))
   )
 }
 const selectAll = () => {
@@ -243,7 +244,7 @@ const onUpdateDropdown = () => {
     if (!currentValue) return
 
     filterableOptions.value.find((option, index) => {
-      if (option.value === currentValue) {
+      if (deepEqual(option.value, currentValue)) {
         selectedIndex = index
         return true
       }
@@ -437,9 +438,9 @@ defineExpose({
                 :is-selected="
                   multiple
                     ? modelValue
-                      ? modelValue.find((o) => o === option.value) !== undefined
+                      ? modelValue.find((o) => deepEqual(o, option.value)) !== undefined
                       : false
-                    : modelValue === option.value
+                    : deepEqual(modelValue, option.value)
                 "
                 @click="selectOption(option)"
               />

--- a/packages/core/src/Form/Select/utils/deepEqual.js
+++ b/packages/core/src/Form/Select/utils/deepEqual.js
@@ -1,0 +1,26 @@
+// Helper function for deep comparison of values (handles arrays, objects, and primitives)
+const deepEqual = (a, b) => {
+  if (a === b) return true
+  
+  if (a == null || b == null) return a === b
+  
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    return a.every((item, index) => deepEqual(item, b[index]))
+  }
+  
+  if (typeof a === 'object' && typeof b === 'object') {
+    const keysA = Object.keys(a)
+    const keysB = Object.keys(b)
+    
+    if (keysA.length !== keysB.length) return false
+    
+    return keysA.every(key => deepEqual(a[key], b[key]))
+  }
+  
+  return false
+}
+
+export {
+  deepEqual
+}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.21.1-39",
+  "version": "1.21.1-40",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.21.1-40",
+  "version": "1.21.1-41",
   "type": "module",
   "scripts": {
     "build": "vite build"


### PR DESCRIPTION
We have Select where values could not only be primitive data types, but also arrays, for example, so we need to add the ability to compare them

<img width="766" height="384" alt="image" src="https://github.com/user-attachments/assets/7c357038-6132-4e13-b39d-0f87ab4d7c56" />

Ref: [linear comment](https://linear.app/hitpay/issue/HIT-13859/fix-applying-table-filters-array-in-value-from-pagestore#comment-bff1d3bd)