### PR TITLE
PageTitle: fix page title button dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.88.0",
+      "version": "1.89.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.88.0",
+      "version": "1.89.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.88.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.88.0.tgz",
+      "integrity": "sha512-0bBjRKdnDXGZRTsD1l8FiXnIp9u2daXrSLs/1DwhKJTQF4eGsMqpgq1iQp85FdD5qb7GTlaBmG6aSzrByvSQdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Elements/PageTitle/OcPageTitle.stories.js
+++ b/packages/core/src/Elements/PageTitle/OcPageTitle.stories.js
@@ -21,6 +21,100 @@ export const Default = {
       isDropdownOpened: false,
       variant: 'secondary',
       label: 'Secondary',
+      onClick: () => {
+        console.log('secondary clicked');
+      },
+    },
+    isBack: false,
+    isCopy: false,
+    chipOptions: null
+  },
+  render: (args) => ({
+    components: { PageTitle, Theme },
+    setup() {
+      return { args }
+    },
+    template: `
+      <Theme>
+        <PageTitle v-bind="args" />
+      </Theme>
+    `
+  })
+}
+
+export const SecondaryMultipleActions = {
+  args: {
+    title: 'Page Title',
+    description: '123',
+    isLoading: false,
+    primaryButtonProps: {
+      leftIcon: 'plus',
+      label: 'Primary',
+      onClick: () => {
+        console.log('click new payment link')
+      }
+    },
+    secondaryButtonProps: {
+      isDropdownOpened: false,
+      variant: 'secondary',
+      label: 'Secondary',
+      isAdditionalArea: true,
+      onClick: () => {
+        console.log('secondary clicked');
+      },
+      additionalAreaIcon: 'chevron-down',
+      dropdownOptions: [
+        {
+          name: 'bulk_create',
+          icon: 'upload',
+          text: 'Bulk create',
+          onClick: () => {
+            console.log('click bulk create')
+          }
+        },
+        {
+          name: 'download',
+          icon: 'download',
+          text: 'Export',
+          onClick: () => {
+            console.log('click download')
+          }
+        }
+      ]
+    },
+    isBack: false,
+    isCopy: false,
+    chipOptions: null
+  },
+  render: (args) => ({
+    components: { PageTitle, Theme },
+    setup() {
+      return { args }
+    },
+    template: `
+      <Theme>
+        <PageTitle v-bind="args" />
+      </Theme>
+    `
+  })
+}
+
+export const HasDropdownButton = {
+  args: {
+    title: 'Page Title',
+    description: '123',
+    isLoading: false,
+    primaryButtonProps: {
+      leftIcon: 'plus',
+      label: 'Primary',
+      onClick: () => {
+        console.log('click new payment link')
+      }
+    },
+    secondaryButtonProps: {
+      isDropdownOpened: true,
+      variant: 'secondary',
+      leftIcon: 'chevron-down',
       dropdownOptions: [
         {
           name: 'bulk_create',

--- a/packages/core/src/Elements/PageTitle/OcPageTitleRight.vue
+++ b/packages/core/src/Elements/PageTitle/OcPageTitleRight.vue
@@ -14,11 +14,43 @@ const props = defineProps({
 
 const isDropdownOpened = ref(props.secondaryButtonProps?.isDropdownOpened ?? false)
 const { isMobile } = useWindowWidth()
+const clickAdditional = (e) => {
+  e.preventDefault()
+  isDropdownOpened.value = !isDropdownOpened.value
+  const { secondaryButtonProps } = props;
+  typeof secondaryButtonProps?.['onAdditionClick'] === 'function' && secondaryButtonProps['onAdditionClick']();
+}
+const clickSecondaryButton = (e) => {
+  const { secondaryButtonProps } = props;
+  if (secondaryButtonProps.additionalAreaIcon && secondaryButtonProps.dropdownOptions) {
+    // need to stop to prevent open dropdown, dropdown should be triggerred on additional icon.
+    e.stopPropagation()
+    e.preventDefault()
+
+    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e);
+
+    return
+  }
+
+  if (!secondaryButtonProps.dropdownOptions) {
+    e.stopPropagation()
+    e.preventDefault()
+
+    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e);
+  }
+}
 </script>
 <template>
   <div v-if="!isLoading" class="flex gap-x-3 items-center">
     <Dropdown v-if="secondaryButtonProps" v-model="isDropdownOpened" :distance="10">
-      <Button :size="isMobile ? 'small' : 'default'" v-bind="secondaryButtonProps" />
+      <Button
+        :size="isMobile ? 'small' : 'default'"
+        v-bind="{
+          ...secondaryButtonProps,
+          onClick: clickSecondaryButton,
+          onAdditionClick: clickAdditional
+        }"
+      />
       <template #menu>
         <div v-if="secondaryButtonProps?.dropdownOptions" class="p-2">
           <DropdownItem

--- a/packages/core/src/Form/Button/OcButton.vue
+++ b/packages/core/src/Form/Button/OcButton.vue
@@ -150,7 +150,7 @@ const iconSize = computed(() => ({
       v-if="isAdditionalArea && !isTransparent"
       class="border-y border-r flex cursor-pointer items-center justify-center oc-btn-add-area px-[6px] py-3 rounded-r-[inherit]"
       :class="[additionalAreaSize[size], variant]"
-      @click.stop="$emit('addition-click')"
+      @click.stop="$emit('addition-click', $event)"
     >
       <slot name="additional-content">
         <Icon :name="additionalAreaIcon" :class="additionalAreaIconSize[size]" />

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.88.0",
+    "@orchidui/core": "1.89.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the PageTitle secondary button dropdown so the chevron toggles the menu and the main button acts normally without opening it. Bumps `@orchidui/core` and `@orchidui/dashboard` to v1.89.0. Addresses Linear HIT-17579.

- **Bug Fixes**
  - Toggle dropdown only from the additional area; emit addition-click with the event and call onAdditionClick when provided.
  - Prevent dropdown opening on the main button when an additional area exists; still invoke onClick and stop event propagation.
  - Add Storybook variants for multiple actions and a pre-opened dropdown to validate the scenarios.

- **Dependencies**
  - Publish v1.89.0 for `@orchidui/core` and `@orchidui/dashboard`; update `@orchidui/dashboard` to depend on `@orchidui/core@1.89.0`.

<sup>Written for commit 9b06f23ff684a60034a2b9f06e9f6af652a0ae95. Summary will update on new commits. <a href="https://cubic.dev/pr/hit-pay/orchid/pull/1255?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

