### PR TITLE
Feature/hit 17564

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.92.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.91.0",
+        "@orchidui/core": "1.92.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.91.0.tgz",
-      "integrity": "sha512-BPA0pl9dVl3dsAgsJsCDHafTI9hu+NyBqcuGFc1DvoeG10a2JXryO6W4tOLpXyRdwkh3ZN1uZk6a+dImWx+/Rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.89.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.88.0",
+        "@orchidui/core": "1.89.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.88.0.tgz",
-      "integrity": "sha512-0bBjRKdnDXGZRTsD1l8FiXnIp9u2daXrSLs/1DwhKJTQF4eGsMqpgq1iQp85FdD5qb7GTlaBmG6aSzrByvSQdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.89.0",
+      "version": "1.90.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.89.0",
+      "version": "1.90.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.89.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.89.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.89.0.tgz",
+      "integrity": "sha512-CyfNZ+b5orxhB0rI8dpDfOpc419nhEc5f4+2ZMs/E/+/rq9r046s+BzA+z5QKpDfZqZ6RX3ilEb4oGu21APtaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.90.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.89.0",
+        "@orchidui/core": "1.90.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.89.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.89.0.tgz",
-      "integrity": "sha512-CyfNZ+b5orxhB0rI8dpDfOpc419nhEc5f4+2ZMs/E/+/rq9r046s+BzA+z5QKpDfZqZ6RX3ilEb4oGu21APtaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.91.0",
+      "version": "1.92.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.91.0",
+      "version": "1.92.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.91.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.91.0.tgz",
+      "integrity": "sha512-BPA0pl9dVl3dsAgsJsCDHafTI9hu+NyBqcuGFc1DvoeG10a2JXryO6W4tOLpXyRdwkh3ZN1uZk6a+dImWx+/Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.90.0",
+      "version": "1.91.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.90.0",
+      "version": "1.91.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.90.0",
+        "@orchidui/core": "1.91.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
@@ -1,0 +1,167 @@
+<script setup>
+import { Button, CustomerCard, Icon, Tooltip } from '@/orchidui-core'
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  /** Flat array of item objects to display. */
+  items: { type: Array, default: () => [] },
+  /** Number of items visible in the preview grid. */
+  initialCount: { type: Number, default: 6 },
+  /** Number of grid columns in the preview. */
+  columns: { type: Number, default: 3 },
+  /** Show a CustomerCard at the bottom of the details panel. */
+  isCustomer: { type: Boolean, default: false },
+  /** Variant passed to the CustomerCard component. */
+  customerCardVariant: { type: String, default: 'big' },
+  /** Customer data object passed to the CustomerCard component. */
+  customer: { type: Object, default: null }
+})
+
+defineEmits({
+  /** "Add customer" button clicked inside the CustomerCard. */
+  addCustomer: []
+})
+
+const isDetailsOpen = ref(false)
+
+const previewItems = computed(() => props.items.slice(0, props.columns))
+
+const getBorderClasses = (index) => {
+  const cols = props.columns
+  const total = previewItems.value.length
+  const isLastInRow = (index + 1) % cols === 0
+  const isInLastRow = index >= total - (total % cols || cols)
+  return {
+    'border-r border-oc-gray-200': !isLastInRow,
+    'border-b border-oc-gray-200': !isInLastRow
+  }
+}
+
+const getEffectiveColSpan = (item, index) => {
+  if (item.colSpan) return item.colSpan
+  if (index !== previewItems.value.length - 1) return null
+  const cols = props.columns
+  const totalGridCols = previewItems.value.reduce((sum, it) => sum + (it.colSpan || 1), 0)
+  const remainder = totalGridCols % cols
+  if (remainder === 0) return null
+  const posInRow = (totalGridCols - (item.colSpan || 1)) % cols
+  const remaining = cols - posInRow
+  return remaining > 1 ? remaining : null
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex flex-col bg-oc-gray-50 border border-oc-gray-200 rounded overflow-hidden">
+      <div :class="`grid grid-cols-${columns}`">
+        <div
+          v-for="(item, i) in previewItems"
+          :key="i"
+          class="flex flex-col gap-y-1 p-3"
+          :class="[getBorderClasses(i), { 'col-span-2': getEffectiveColSpan(item, i) === 2, 'col-span-3': getEffectiveColSpan(item, i) === 3 }]"
+        >
+          <div class="flex items-center gap-x-2">
+            <span class="text-oc-text-400">{{ item.title }}</span>
+            <Tooltip v-if="item.info" :popper-options="{ strategy: 'fixed' }">
+              <Icon name="information" class="text-oc-text-400" width="16" height="16" />
+              <template #popper>
+                <slot :name="item.tooltipSlot ?? `${item.slot}-tooltip`">
+                  <div class="py-2 px-3 text-oc-text-400">{{ item.tooltip }}</div>
+                </slot>
+              </template>
+            </Tooltip>
+          </div>
+          <slot v-if="item.slot && $slots[item.slot]" :name="item.slot" :data="item" />
+          <span v-else class="font-medium truncate" :class="item.class">{{ item.content }}</span>
+        </div>
+      </div>
+
+      <div class="border-t border-oc-gray-200 flex justify-center">
+        <Button
+          class="px-3"
+          label="See details ->"
+          size="small"
+          is-transparent
+          @click="isDetailsOpen = true"
+        />
+      </div>
+    </div>
+
+    <Transition name="slow-fade">
+      <div
+        v-if="isDetailsOpen"
+        class="fixed z-[1005] top-0 left-0 w-screen flex justify-end h-screen bg-black/[.45]"
+        @click="isDetailsOpen = false"
+      />
+    </Transition>
+
+    <Transition name="slide-from-right">
+      <div
+        v-if="isDetailsOpen"
+        class="max-w-[280px] fixed z-[1006] top-0 right-0 transition-all duration-500 flex flex-col w-full bg-white h-screen overflow-y-auto"
+      >
+        <div class="p-5 flex items-center justify-between border-b border-oc-gray-200">
+          <span class="font-medium">Details</span>
+          <Button
+            size="small"
+            left-icon="x"
+            label="Close"
+            is-transparent
+            class="px-3"
+            variant="secondary"
+            @click="isDetailsOpen = false"
+          />
+        </div>
+
+        <div class="px-5 py-4 flex-1 flex flex-col gap-y-4">
+          <div
+            v-for="(item, i) in items"
+            :key="i"
+            class="flex flex-col gap-y-1"
+          >
+            <div class="flex items-center gap-x-2">
+              <span class="text-sm text-oc-text-400">{{ item.title }}</span>
+              <Tooltip v-if="item.info" :popper-options="{ strategy: 'fixed' }">
+                <Icon name="information" class="text-oc-text-400" width="14" height="14" />
+                <template #popper>
+                  <slot :name="item.tooltipSlot ?? `${item.slot}-tooltip`">
+                    <div class="py-2 px-3 text-oc-text-400">{{ item.tooltip }}</div>
+                  </slot>
+                </template>
+              </Tooltip>
+            </div>
+            <slot v-if="item.slot && $slots[item.slot]" :name="item.slot" :data="item" />
+            <span v-else class="font-medium" :class="item.class">{{ item.content }}</span>
+          </div>
+
+          <CustomerCard
+            v-if="isCustomer"
+            :variant="customerCardVariant"
+            :customer="customer"
+            class="mt-2"
+            @add-customer="$emit('addCustomer')"
+          />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style lang="scss">
+.slide-from-right-enter-active,
+.slide-from-right-leave-active,
+.slow-fade-enter-active,
+.slow-fade-leave-active {
+  transition: all 0.3s ease-in-out;
+}
+
+.slow-fade-enter-from { opacity: 0; }
+.slow-fade-enter-to   { opacity: 1; }
+.slow-fade-leave-from { opacity: 1; }
+.slow-fade-leave-to   { opacity: 0; }
+
+.slide-from-right-enter-from { transform: translateX(100%); }
+.slide-from-right-enter-to   { transform: translateX(0); }
+.slide-from-right-leave-from { transform: translateX(0); }
+.slide-from-right-leave-to   { transform: translateX(100%); }
+</style>

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
@@ -5,8 +5,6 @@ import { ref, computed } from 'vue'
 const props = defineProps({
   /** Flat array of item objects to display. */
   items: { type: Array, default: () => [] },
-  /** Number of items visible in the preview grid. */
-  initialCount: { type: Number, default: 6 },
   /** Number of grid columns in the preview. */
   columns: { type: Number, default: 3 },
   /** Show a CustomerCard at the bottom of the details panel. */
@@ -14,12 +12,16 @@ const props = defineProps({
   /** Variant passed to the CustomerCard component. */
   customerCardVariant: { type: String, default: 'big' },
   /** Customer data object passed to the CustomerCard component. */
-  customer: { type: Object, default: null }
+  customer: { type: Object, default: null },
+  /** Enable edit mode on the CustomerCard. */
+  customerIsEdit: { type: Boolean, default: false }
 })
 
 defineEmits({
   /** "Add customer" button clicked inside the CustomerCard. */
-  addCustomer: []
+  addCustomer: [],
+  /** "Edit customer" action triggered. Payload: customer event data. */
+  editCustomer: []
 })
 
 const isDetailsOpen = ref(false)
@@ -138,8 +140,10 @@ const getEffectiveColSpan = (item, index) => {
             v-if="isCustomer"
             :variant="customerCardVariant"
             :customer="customer"
+            :is-edit="customerIsEdit"
             class="mt-2"
             @add-customer="$emit('addCustomer')"
+            @edit-customer="$emit('editCustomer', $event)"
           />
         </div>
       </div>

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { CustomerCard, Icon, Tooltip, Button } from '@/orchidui-core'
-import { useWindowWidth } from '../../../composables/useWindowWidth.js'
+import MobileExpandingType from './MobileExpandingType.vue'
 import { ref, computed } from 'vue'
 
 const props = defineProps({
@@ -29,11 +29,7 @@ defineEmits({
   editCustomer: null
 })
 
-const { isMobile } = useWindowWidth()
-
 const isExpanded = ref(false)
-
-const effectiveColumns = computed(() => (isMobile.value ? 1 : props.columns))
 
 const visibleItems = computed(() =>
   isExpanded.value ? props.items : props.items.slice(0, props.initialCount)
@@ -42,7 +38,7 @@ const visibleItems = computed(() =>
 const hasMore = computed(() => props.items.length > props.initialCount)
 
 const getBorderClasses = (index) => {
-  const cols = effectiveColumns.value
+  const cols = props.columns
   const total = visibleItems.value.length
   const isLastInRow = (index + 1) % cols === 0
   const isInLastRow = index >= total - (total % cols || cols)
@@ -51,15 +47,44 @@ const getBorderClasses = (index) => {
     'border-b': !isInLastRow
   }
 }
+
+const getEffectiveColSpan = (item, index) => {
+  if (item.colSpan) return item.colSpan
+  if (index !== visibleItems.value.length - 1) return null
+  const cols = props.columns
+  const totalGridCols = visibleItems.value.reduce((sum, it) => sum + (it.colSpan || 1), 0)
+  const remainder = totalGridCols % cols
+  if (remainder === 0) return null
+  const posInRow = (totalGridCols - (item.colSpan || 1)) % cols
+  const remaining = cols - posInRow
+  return remaining > 1 ? remaining : null
+}
 </script>
 
 <template>
-  <div class="flex flex-col md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
-    <div class="relative flex-1" :class="[`grid grid-cols-${effectiveColumns}`, hasMore ? 'mb-8 md:mb-0' : '']">
+  <!-- Mobile -->
+  <MobileExpandingType
+    class="flex md:hidden"
+    :items="items"
+    :initial-count="initialCount"
+    :columns="columns"
+    :is-customer="isCustomer"
+    :customer-card-variant="customerCardVariant"
+    :customer="customer"
+    @add-customer="$emit('addCustomer')"
+  >
+    <template v-for="(_, name) in $slots" #[name]="slotData">
+      <slot :name="name" v-bind="slotData" />
+    </template>
+  </MobileExpandingType>
+
+  <!-- Desktop -->
+  <div class="hidden md:flex md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
+    <div class="relative flex-1" :class="[`grid grid-cols-${columns}`, hasMore ? 'md:mb-0' : '']">
       <div
         v-for="(item, index) in visibleItems"
         :key="index"
-        :class="[getBorderClasses(index), { 'cursor-pointer': typeof item.onClick === 'function' }]"
+        :class="[getBorderClasses(index), { 'cursor-pointer': typeof item.onClick === 'function' }, { 'col-span-2': getEffectiveColSpan(item, index) === 2, 'col-span-3': getEffectiveColSpan(item, index) === 3 }]"
         class="p-4 flex flex-col gap-y-1 group"
         @click="item.onClick?.()"
       >
@@ -84,7 +109,7 @@ const getBorderClasses = (index) => {
           <span>{{ item.content }}</span>
           <Button
             v-if="item.button"
-            class="ml-auto inline-block md:hidden md:group-hover:inline-block [&>button]:h-[unset] [&>button]:border [&>button]:border-oc-gray-200"
+            class="ml-auto hidden group-hover:inline-block [&>button]:h-[unset] [&>button]:border [&>button]:border-oc-gray-200"
             v-bind="item.button"
           />
         </div>
@@ -92,7 +117,7 @@ const getBorderClasses = (index) => {
 
       <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center z-10">
         <div
-          class="rounded md:rounded-t-none border cursor-pointer border-oc-gray-200 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
+          class="rounded-b border cursor-pointer border-oc-gray-200 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
           @click="isExpanded = !isExpanded"
         >
           <Icon :name="isExpanded ? 'arrow-up-down-2' : 'arrow-up-down'" width="16" height="16" />
@@ -101,7 +126,7 @@ const getBorderClasses = (index) => {
       </div>
     </div>
 
-    <div v-if="isCustomer" class="flex bg-oc-accent-1-50 flex-col md:border-l border-oc-gray-200 md:max-w-[250px] shrink-0 w-full">
+    <div v-if="isCustomer" class="flex bg-oc-accent-1-50 flex-col md:border-l border-oc-gray-200 md:max-w-[250px] shrink-0 w-full md:rounded-r">
       <CustomerCard
         :variant="customerCardVariant"
         :customer="customer"

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -66,12 +66,13 @@ const getEffectiveColSpan = (item, index) => {
   <MobileExpandingType
     class="flex md:hidden"
     :items="items"
-    :initial-count="initialCount"
     :columns="columns"
     :is-customer="isCustomer"
     :customer-card-variant="customerCardVariant"
     :customer="customer"
+    :customer-is-edit="customerIsEdit"
     @add-customer="$emit('addCustomer')"
+    @edit-customer="$emit('editCustomer', $event)"
   >
     <template v-for="(_, name) in $slots" #[name]="slotData">
       <slot :name="name" v-bind="slotData" />

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { CustomerCard, Icon, Tooltip, Button } from '@/orchidui-core'
+import { useWindowWidth } from '../../../composables/useWindowWidth.js'
 import { ref, computed } from 'vue'
 
 const props = defineProps({
@@ -28,7 +29,11 @@ defineEmits({
   editCustomer: null
 })
 
+const { isMobile } = useWindowWidth()
+
 const isExpanded = ref(false)
+
+const effectiveColumns = computed(() => (isMobile.value ? 1 : props.columns))
 
 const visibleItems = computed(() =>
   isExpanded.value ? props.items : props.items.slice(0, props.initialCount)
@@ -37,9 +42,10 @@ const visibleItems = computed(() =>
 const hasMore = computed(() => props.items.length > props.initialCount)
 
 const getBorderClasses = (index) => {
+  const cols = effectiveColumns.value
   const total = visibleItems.value.length
-  const isLastInRow = (index + 1) % props.columns === 0
-  const isInLastRow = index >= total - (total % props.columns || props.columns)
+  const isLastInRow = (index + 1) % cols === 0
+  const isInLastRow = index >= total - (total % cols || cols)
   return {
     'border-r': !isLastInRow,
     'border-b': !isInLastRow
@@ -49,7 +55,7 @@ const getBorderClasses = (index) => {
 
 <template>
   <div class="flex flex-col md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
-    <div class="relative flex-1" :class="[`grid grid-cols-${columns}`, hasMore ? 'mb-8 md:mb-0' : '']">
+    <div class="relative flex-1" :class="[`grid grid-cols-${effectiveColumns}`, hasMore ? 'mb-8 md:mb-0' : '']">
       <div
         v-for="(item, index) in visibleItems"
         :key="index"
@@ -78,7 +84,7 @@ const getBorderClasses = (index) => {
           <span>{{ item.content }}</span>
           <Button
             v-if="item.button"
-            class="ml-auto hidden group-hover:inline-block [&>button]:h-[unset]"
+            class="ml-auto inline-block md:hidden md:group-hover:inline-block [&>button]:h-[unset] [&>button]:border [&>button]:border-oc-gray-200"
             v-bind="item.button"
           />
         </div>
@@ -86,7 +92,7 @@ const getBorderClasses = (index) => {
 
       <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center z-10">
         <div
-          class="rounded-b border cursor-pointer border-oc-gray-200 border-t-0 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
+          class="rounded md:rounded-t-none border cursor-pointer border-oc-gray-200 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
           @click="isExpanded = !isExpanded"
         >
           <Icon :name="isExpanded ? 'arrow-up-down-2' : 'arrow-up-down'" width="16" height="16" />
@@ -95,22 +101,23 @@ const getBorderClasses = (index) => {
       </div>
     </div>
 
-    <CustomerCard
-      v-if="isCustomer"
-      :variant="customerCardVariant"
-      :customer="customer"
-      :is-hover="customerIsHover"
-      :is-edit="customerIsEdit"
-      class="flex bg-oc-accent-1-50 flex-col md:border-l border-t md:border-t-0 border-oc-gray-200 md:max-w-[250px] shrink-0 w-full border-0 bg-transparent"
-      @add-customer="$emit('addCustomer')"
-      @edit-customer="$emit('editCustomer', $event)"
-    >
-      <template v-if="$slots['customer-leading']" #leading>
-        <slot name="customer-leading" />
-      </template>
-      <template v-if="$slots['customer-bottom']" #bottom>
-        <slot name="customer-bottom" />
-      </template>
-    </CustomerCard>
+    <div v-if="isCustomer" class="flex bg-oc-accent-1-50 flex-col md:border-l border-oc-gray-200 md:max-w-[250px] shrink-0 w-full">
+      <CustomerCard
+        :variant="customerCardVariant"
+        :customer="customer"
+        :is-hover="customerIsHover"
+        :is-edit="customerIsEdit"
+        class="border-0 bg-transparent"
+        @add-customer="$emit('addCustomer')"
+        @edit-customer="$emit('editCustomer', $event)"
+      >
+        <template v-if="$slots['customer-leading']" #leading>
+          <slot name="customer-leading" />
+        </template>
+        <template v-if="$slots['customer-bottom']" #bottom>
+          <slot name="customer-bottom" />
+        </template>
+      </CustomerCard>
+    </div>
   </div>
 </template>

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -48,7 +48,7 @@ const getBorderClasses = (index) => {
 </script>
 
 <template>
-  <div class="flex bg-oc-gray-50 border border-oc-gray-200 rounded">
+  <div class="flex flex-col md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
     <div class="relative flex-1" :class="`grid grid-cols-${columns}`">
       <div
         v-for="(item, index) in visibleItems"
@@ -101,7 +101,7 @@ const getBorderClasses = (index) => {
       :customer="customer"
       :is-hover="customerIsHover"
       :is-edit="customerIsEdit"
-      class="flex bg-oc-accent-1-50 flex-col border-l border-oc-gray-200 max-w-[250px] shrink-0 w-full border-0 bg-transparent"
+      class="flex bg-oc-accent-1-50 flex-col md:border-l border-t md:border-t-0 border-oc-gray-200 md:max-w-[250px] shrink-0 w-full border-0 bg-transparent"
       @add-customer="$emit('addCustomer')"
       @edit-customer="$emit('editCustomer', $event)"
     >

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -49,7 +49,7 @@ const getBorderClasses = (index) => {
 
 <template>
   <div class="flex flex-col md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
-    <div class="relative flex-1" :class="`grid grid-cols-${columns}`">
+    <div class="relative flex-1" :class="[`grid grid-cols-${columns}`, hasMore ? 'mb-8 md:mb-0' : '']">
       <div
         v-for="(item, index) in visibleItems"
         :key="index"
@@ -84,7 +84,7 @@ const getBorderClasses = (index) => {
         </div>
       </div>
 
-      <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center">
+      <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center z-10">
         <div
           class="rounded-b border cursor-pointer border-oc-gray-200 border-t-0 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
           @click="isExpanded = !isExpanded"

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -1,0 +1,116 @@
+<script setup>
+import { CustomerCard, Icon, Tooltip, Button } from '@/orchidui-core'
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  /** Flat array of item objects to display in the grid. */
+  items: { type: Array, default: () => [] },
+  /** Number of items visible before "Show more" is clicked. */
+  initialCount: { type: Number, default: 6 },
+  /** Number of grid columns. */
+  columns: { type: Number, default: 3 },
+  /** Show a CustomerCard on the right side. */
+  isCustomer: { type: Boolean, default: false },
+  /** Variant passed to the CustomerCard component. */
+  customerCardVariant: { type: String, default: 'big' },
+  /** Customer data object passed to the CustomerCard component. */
+  customer: { type: Object, default: null },
+  /** Enable hover state on the CustomerCard. */
+  customerIsHover: { type: Boolean, default: false },
+  /** Enable edit mode on the CustomerCard. */
+  customerIsEdit: { type: Boolean, default: false }
+})
+
+defineEmits({
+  /** "Add customer" button clicked inside the CustomerCard. */
+  addCustomer: null,
+  /** "Edit customer" action triggered. Payload: customer event data. */
+  editCustomer: null
+})
+
+const isExpanded = ref(false)
+
+const visibleItems = computed(() =>
+  isExpanded.value ? props.items : props.items.slice(0, props.initialCount)
+)
+
+const hasMore = computed(() => props.items.length > props.initialCount)
+
+const getBorderClasses = (index) => {
+  const total = visibleItems.value.length
+  const isLastInRow = (index + 1) % props.columns === 0
+  const isInLastRow = index >= total - (total % props.columns || props.columns)
+  return {
+    'border-r': !isLastInRow,
+    'border-b': !isInLastRow
+  }
+}
+</script>
+
+<template>
+  <div class="flex bg-oc-gray-50 border border-oc-gray-200 rounded">
+    <div class="relative flex-1" :class="`grid grid-cols-${columns}`">
+      <div
+        v-for="(item, index) in visibleItems"
+        :key="index"
+        :class="[getBorderClasses(index), { 'cursor-pointer': typeof item.onClick === 'function' }]"
+        class="p-4 flex flex-col gap-y-1 group"
+        @click="item.onClick?.()"
+      >
+        <div class="flex items-center gap-x-2">
+          <span class="text-oc-text-400">{{ item.title }}</span>
+          <Tooltip v-if="item.info" :popper-options="{ strategy: 'fixed' }">
+            <Icon name="information" class="text-oc-text-400" width="16" height="16" />
+            <template #popper>
+              <slot :name="item.tooltipSlot ?? `${item.slot}-tooltip`">
+                <div class="py-2 px-3 text-oc-text-400">{{ item.tooltip }}</div>
+              </slot>
+            </template>
+          </Tooltip>
+        </div>
+
+        <slot v-if="item.slot && $slots[item.slot]" :name="item.slot" :data="item" />
+        <div
+          v-else
+          class="overflow-hidden text-ellipsis flex items-center"
+          :class="item.class"
+        >
+          <span>{{ item.content }}</span>
+          <Button
+            v-if="item.button"
+            class="ml-auto hidden group-hover:inline-block [&>button]:h-[unset]"
+            v-bind="item.button"
+          />
+        </div>
+      </div>
+
+      <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center">
+        <div
+          class="rounded-b border cursor-pointer border-oc-gray-200 border-t-0 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
+          @click="isExpanded = !isExpanded"
+        >
+          <Icon :name="isExpanded ? 'arrow-up-down-2' : 'arrow-up-down'" width="16" height="16" />
+          <span>{{ isExpanded ? 'Show less' : 'Show more' }}</span>
+        </div>
+      </div>
+    </div>
+
+    <CustomerCard
+      v-if="isCustomer"
+      :variant="customerCardVariant"
+      :customer="customer"
+      :is-hover="customerIsHover"
+      :is-edit="customerIsEdit"
+      class="flex bg-oc-accent-1-50 flex-col border-l border-oc-gray-200 max-w-[250px] shrink-0 w-full border-0 bg-transparent"
+      @add-customer="$emit('addCustomer')"
+      @edit-customer="$emit('editCustomer', $event)"
+    >
+      <template v-if="$slots['customer-leading']" #leading>
+        <slot name="customer-leading" />
+      </template>
+      <template v-if="$slots['customer-bottom']" #bottom>
+        <slot name="customer-bottom" />
+      </template>
+    </CustomerCard>
+  </div>
+</template>

--- a/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
+++ b/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
@@ -8,6 +8,8 @@ import BalanceExample from './examples/Balance.vue'
 import BalanceRaw from './examples/Balance.vue?raw'
 import ExpandingExample from './examples/Expanding.vue'
 import ExpandingRaw from './examples/Expanding.vue?raw'
+import ExpandingCustomerInfoExample from './examples/ExpandingCustomerInfo.vue'
+import ExpandingCustomerInfoRaw from './examples/ExpandingCustomerInfo.vue?raw'
 
 export default {
   component: AdditionalContent,
@@ -228,5 +230,21 @@ export const Expanding = {
   render: () => ({
     components: { ExpandingExample, Theme },
     template: `<Theme class="p-4"><ExpandingExample /></Theme>`
+  })
+}
+
+export const ExpandingCustomerInfo = {
+  description: 'Expanding variant used as a customer info card — flat grid of customer detail fields with no show-more toggle (all fields visible by default). Mirrors the CustomerInfoCard pattern but uses the expanding layout instead of dynamic boxes.',
+  highlights: [
+    'variant="expanding"',
+    'expanding-columns="3" — three-column grid',
+    'expanding-initial-count="6" — all fields visible by default, no toggle needed',
+    'REMARKS field conditionally included via spread',
+    'No CustomerCard — customer data is the content itself'
+  ],
+  code: ExpandingCustomerInfoRaw,
+  render: () => ({
+    components: { ExpandingCustomerInfoExample, Theme },
+    template: `<Theme class="p-4"><ExpandingCustomerInfoExample /></Theme>`
   })
 }

--- a/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
+++ b/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.stories.js
@@ -1,357 +1,232 @@
 import { AdditionalContent, OverviewItem, Theme } from '@/orchidui-core'
+import { ref } from 'vue'
+import DefaultExample from './examples/Default.vue'
+import DefaultRaw from './examples/Default.vue?raw'
+import DynamicExample from './examples/Dynamic.vue'
+import DynamicRaw from './examples/Dynamic.vue?raw'
+import BalanceExample from './examples/Balance.vue'
+import BalanceRaw from './examples/Balance.vue?raw'
+import ExpandingExample from './examples/Expanding.vue'
+import ExpandingRaw from './examples/Expanding.vue?raw'
 
 export default {
   component: AdditionalContent,
-  tags: ['autodocs']
-}
-
-const argTypes = {
-  variant: {
-    control: 'select',
-    options: ['default', 'dynamic', 'balance']
-  },
-  customerCardVariant: {
-    control: 'select',
-    options: ['small', 'big', 'float']
-  },
-  overviewActiveTab: {
-    control: 'select',
-    options: ['hitpay', 'card']
-  },
-  boxes: {
-    control: 'select',
-    options: {
-      '5 Fields in 2 boxes': [
-        {
-          showInfo: false,
-          infoTooltip: 'Tooltip',
-          items: [
-            {
-              title: 'Purpose',
-              content: 'Premium GYM membership'
-            },
-            {
-              title: 'ID',
-              content: '9a2f500c-545d-4db6-84fa-c40d65146f43'
-            },
-            {
-              title: 'reference',
-              content: '9a2f500c-545d-4db6-84fa-c40d65146f43'
-            }
-          ]
-        },
-        {
-          showInfo: false,
-          infoTooltip: 'Tooltip',
-          items: [
-            {
-              title: 'Created at',
-              content: '20/11/2023'
-            },
-            {
-              title: 'Expired at',
-              content: '20/12/2023'
-            }
-          ]
-        }
-      ],
-      '4 Fields': [
-        {
-          showInfo: true,
-          infoTooltip: 'Tooltip',
-          infoTooltipStyle: 'absolute right-3',
-          infoTooltipSlot: 'BoxInfoTooltip',
-          style: '!grid-cols-2 relative pr-10',
-          slot: 'Box',
-          items: [
-            {
-              title: 'Purpose',
-              content: 'Premium GYM membership'
-            },
-            {
-              title: 'ID',
-              content: '9a2f500c-545d-4db6-84fa-c40d65146f43'
-            },
-            {
-              title: 'reference',
-              content: '9a2f500c-545d-4db6-84fa-c40d65146f43'
-            },
-            {
-              title: 'reference',
-              content: '9a2f500c-545d-4db6-84fa-c40d65146f43'
-            }
-          ]
-        }
-      ]
-    }
-  },
-  chipVariant: {
-    control: 'select',
-    options: ['accent-1', 'accent-2', 'success', 'warning', 'error', 'gray', '']
-  }
-}
-
-const args = {
-  mainLink: 'https://securecheckout.staging.hit-pay.com/payment-request',
-  userId: '/@minstore-edit43',
-  chipVariant: 'success',
-  isLoading: false,
-  chipLabel: 'Active',
-  additionalTitle: 'Need attention',
-  primaryActions: {
-    mainLinkAction: {
-      tooltipContent: 'Preview Link',
-      url: 'https://securecheckout.staging.hit-pay.com/payment-request/@minstore-edit43'
-    },
-    copyTooltipContent: 'Copy payment link',
-    copiedTooltipContent: 'Payment link copied!',
-    dropdownOptions: {
-      isDropdownOpened: false,
-      top: [
-        {
-          icon: 'pencil',
-          text: 'Customize link',
-          onClick: () => console.log('customize link clicked')
-        },
-        {
-          isCopyButton: true
-        },
-        {
-          icon: 'eye-open',
-          text: 'View details',
-          onClick: () => console.log('view details clicked')
-        }
-      ],
-      bottom: [
-        {
-          text: 'Activate',
-          icon: 'toggle-right-fill',
-          iconClasses: '!text-oc-success',
-          onClick: () => console.log('activate/disactivate clicked')
-        }
-      ]
-    },
-    actions: [
-      {
-        isCopyButton: true
-      },
-      {
-        icon: 'pencil',
-        tooltipContent: 'Edit',
-        onClick: () => {
-          console.log('clicked')
-        }
-      }
-    ]
-  },
-  variant: 'default',
-  boxes: [],
-  isCustomer: false,
-  overviewItems: [
-    {
-      title: 'Total revenue',
-      content: 'SGD 11,170.00',
-      icon: 'coins',
-      iconProps: {
-        class: 'text-oc-primary'
-      },
-      isFooter: true
-    },
-    {
-      title: 'This month',
-      content: 'SGD 1,870.00',
-      icon: 'coin',
-      iconProps: {
-        class: 'text-oc-accent-1'
-      }
-    },
-    {
-      title: 'Completed',
-      content: '20',
-      icon: 'check',
-      iconProps: {
-        class: 'text-oc-success'
-      }
-    },
-    {
-      title: 'Refunded',
-      content: '3',
-      icon: 'backward',
-      iconProps: {
-        class: 'text-oc-error'
-      }
-    }
+  tags: ['autodocs'],
+  kind: 'composite',
+  description: 'A contextual header section that sits below the page title. Switches between four layout variants: default (link + chip + actions), dynamic (grouped overview boxes + optional customer card), balance (financial overview with tabs), and expanding (flat grid with show-more + optional customer card).',
+  keywords: ['additional content', 'overview', 'header', 'customer card', 'expanding', 'balance', 'dynamic'],
+  use_for: [
+    'transaction or payment detail pages',
+    'customer or entity detail headers',
+    'financial overview summaries',
+    'expandable metadata grids',
+    'payment link detail pages'
   ],
-  overviewTabs: [
-    {
-      title: 'HitPay Balance',
-      content: 'SGD 1,110.00',
-      value: 'hitpay',
-      countryIso: 'SG'
-    },
-    {
-      title: 'Card Balance',
-      content: 'SGD 1000.00',
-      value: 'card'
-    }
-  ],
-  overviewActiveTab: 'hitpay',
-  customerCardVariant: 'big',
-  customer: {
-    name: 'Alex Turner',
-    email: 'alex@arcticmonkey.io',
-    phone: '+65 8373 3739 18',
-    address: {
-      street: '123 Main Street',
-      city: 'Pennsylvania',
-      state: 'Pennsylvania',
-      postal_code: '12345 ',
-      country: 'USA'
-    }
-  }
+  understand_with: ['CustomerCard', 'OverviewItem', 'PrimaryActions', 'Chip', 'Button', 'Tooltip']
 }
 
-export const Default = {
-  argTypes,
-  args,
+// ── Playground ────────────────────────────────────────────────────────────────
+
+export const Playground = {
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'dynamic', 'balance', 'expanding'],
+      description: 'Layout variant to render'
+    },
+    // default variant
+    additionalTitle:  { control: 'text',    description: 'default — heading text' },
+    chipVariant:      { control: 'select',  options: ['accent-1', 'accent-2', 'success', 'warning', 'error', 'gray', ''], description: 'default — chip color' },
+    chipLabel:        { control: 'text',    description: 'default — chip label text' },
+    // shared
+    isCustomer:       { control: 'boolean', description: 'dynamic / expanding — show CustomerCard' },
+    customerCardVariant: { control: 'select', options: ['small', 'big', 'float'], description: 'CustomerCard size variant' },
+    customerIsHover:  { control: 'boolean', description: 'dynamic — hover state on CustomerCard' },
+    customerIsEdit:   { control: 'boolean', description: 'dynamic — edit state on CustomerCard' },
+    isLoading:        { control: 'boolean', description: 'default — show skeleton placeholders' },
+    // expanding variant
+    expandingInitialCount: { control: 'number', description: 'expanding — items shown before "Show more"' },
+    expandingColumns:      { control: 'number', description: 'expanding — number of grid columns' },
+    // balance variant
+    overviewActiveTab: { control: 'select', options: ['hitpay', 'card'], description: 'balance — active tab value' }
+  },
+  args: {
+    variant: 'default',
+    additionalTitle: 'Premium Store',
+    chipVariant: 'success',
+    chipLabel: 'Active',
+    isCustomer: false,
+    customerCardVariant: 'big',
+    customerIsHover: false,
+    customerIsEdit: false,
+    isLoading: false,
+    expandingInitialCount: 6,
+    expandingColumns: 3,
+    overviewActiveTab: 'hitpay'
+  },
   render: (args) => ({
-    components: { AdditionalContent, Theme },
+    components: { AdditionalContent, OverviewItem, Theme },
     setup() {
-      return { args }
+      const activeTab = ref(args.overviewActiveTab)
+
+      const primaryActions = {
+        mainLinkAction: {
+          tooltipContent: 'Preview Link',
+          url: 'https://securecheckout.staging.hit-pay.com/payment-request/@minstore-edit43'
+        },
+        copyTooltipContent: 'Copy payment link',
+        copiedTooltipContent: 'Payment link copied!',
+        actions: [
+          { isCopyButton: true },
+          { icon: 'pencil', tooltipContent: 'Edit', onClick: () => console.log('edit') }
+        ]
+      }
+
+      const customer = {
+        name: 'Alex Turner',
+        email: 'alex@arcticmonkey.io',
+        phone: '+65 8373 3739',
+        address: { street: '123 Main Street', city: 'Pennsylvania', state: 'Pennsylvania', postal_code: '12345', country: 'USA' }
+      }
+
+      const dynamicBoxes = [
+        {
+          showInfo: false,
+          items: [
+            { title: 'Purpose',   content: 'Premium GYM membership' },
+            { title: 'ID',        content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+            { title: 'Reference', content: '9a2f500c-545d-4db6-84fa-c40d65146f43' }
+          ]
+        },
+        {
+          showInfo: false,
+          items: [
+            { title: 'Created at', content: '20/11/2023' },
+            { title: 'Expired at', content: '20/12/2023' }
+          ]
+        }
+      ]
+
+      const expandingItems = [
+        { title: 'Purpose',    content: 'Premium GYM membership' },
+        { title: 'ID',         content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+        { title: 'Reference',  content: 'REF-20231120-001' },
+        { title: 'Created at', content: '20/11/2023' },
+        { title: 'Expired at', content: '20/12/2023' },
+        { title: 'Status',     content: 'Completed', class: 'text-oc-success' },
+        { title: 'Amount',     content: 'SGD 150.00' },
+        { title: 'Channel',    content: 'Point of sale', info: true, tooltip: 'The payment channel used for this transaction' },
+        { title: 'Fee',        content: 'SGD 2.50' }
+      ]
+
+      const overviewItems = [
+        { title: 'Total revenue', content: 'SGD 11,170.00', icon: 'coins',    iconProps: { class: 'text-oc-primary' },   isFooter: true },
+        { title: 'This month',    content: 'SGD 1,870.00',  icon: 'coin',     iconProps: { class: 'text-oc-accent-1' } },
+        { title: 'Completed',     content: '20',            icon: 'check',    iconProps: { class: 'text-oc-success' } },
+        { title: 'Refunded',      content: '3',             icon: 'backward', iconProps: { class: 'text-oc-error' } }
+      ]
+
+      const overviewTabs = [
+        { title: 'HitPay Balance', content: 'SGD 1,110.00', value: 'hitpay', countryIso: 'SG' },
+        { title: 'Card Balance',   content: 'SGD 1,000.00', value: 'card' }
+      ]
+
+      return { args, activeTab, primaryActions, customer, dynamicBoxes, expandingItems, overviewItems, overviewTabs }
     },
     template: `
-      <Theme class="h-[300px]">
+      <Theme class="min-h-[300px] p-4">
         <AdditionalContent
-          :main-link="args.mainLink"
-          :chip-label="args.chipLabel"
+          :variant="args.variant"
+          main-link="https://securecheckout.staging.hit-pay.com/payment-request"
+          user-id="/@minstore-edit43"
           :additional-title="args.additionalTitle"
           :chip-variant="args.chipVariant"
-          :user-id="args.userId"
-          :primary-actions="args.primaryActions"
-          :variant="args.variant ?? 'default'"
-          :boxes="args.boxes"
-          :overview-items="args.overviewItems"
-          :overview-tabs="args.overviewTabs"
-          :customer-card-variant="args.customerCardVariant"
-          :is-customer="args.isCustomer"
-          :customer="args.customer"
-          :overview-active-tab="args.overviewActiveTab"
+          :chip-label="args.chipLabel"
+          :primary-actions="primaryActions"
           :is-loading="args.isLoading"
-          @change-tab="args.overviewActiveTab = $event"
+          :boxes="dynamicBoxes"
+          :expanding-items="expandingItems"
+          :expanding-initial-count="args.expandingInitialCount"
+          :expanding-columns="args.expandingColumns"
+          :is-customer="args.isCustomer"
+          :customer="customer"
+          :customer-card-variant="args.customerCardVariant"
+          :customer-is-hover="args.customerIsHover"
+          :customer-is-edit="args.customerIsEdit"
+          :overview-items="overviewItems"
+          :overview-tabs="overviewTabs"
+          :overview-active-tab="activeTab"
+          @change-tab="activeTab = $event"
+          @add-customer="console.log('add customer')"
+          @edit-customer="console.log('edit customer', $event)"
         />
       </Theme>
     `
+  })
+}
+
+// ── Stories ───────────────────────────────────────────────────────────────────
+
+export const Default = {
+  description: 'Shows a title, chip status, a full link with copy/open actions, and a dropdown. Use this variant on detail pages where the entity has a public URL (payment links, stores).',
+  highlights: [
+    'variant="default"',
+    'main-link + user-id — compose the full URL',
+    'chip-variant + chip-label — status badge',
+    'primary-actions — copy / open / dropdown buttons'
+  ],
+  code: DefaultRaw,
+  render: () => ({
+    components: { DefaultExample, Theme },
+    template: `<Theme class="p-4"><DefaultExample /></Theme>`
   })
 }
 
 export const Dynamic = {
-  args,
-  argTypes,
-  render: (args) => ({
-    components: { AdditionalContent, Theme, OverviewItem },
-    setup() {
-      return { args, argTypes }
-    },
-    template: `
-      <Theme class="h-[300px]">
-        <AdditionalContent
-          :main-link="args.mainLink"
-          :chip-label="args.chipLabel"
-          :additional-title="args.additionalTitle"
-          :chip-variant="args.chipVariant"
-          :user-id="args.userId"
-          :primary-actions="args.primaryActions"
-          variant="dynamic"
-          :boxes="argTypes['boxes'].options['5 Fields in 2 boxes']"
-          :overview-items="args.overviewItems"
-          :overview-tabs="args.overviewTabs"
-          :customer-card-variant="args.customerCardVariant"
-          :is-customer="args.isCustomer"
-          :customer="args.customer"
-          :overview-active-tab="args.overviewActiveTab"
-          @change-tab="args.overviewActiveTab = $event"
-        />
-        <AdditionalContent
-          :main-link="args.mainLink"
-          :chip-label="args.chipLabel"
-          :additional-title="args.additionalTitle"
-          :chip-variant="args.chipVariant"
-          :user-id="args.userId"
-          :primary-actions="args.primaryActions"
-          variant="dynamic"
-          :boxes="argTypes['boxes'].options['4 Fields']"
-          :overview-items="args.overviewItems"
-          :overview-tabs="args.overviewTabs"
-          :customer-card-variant="args.customerCardVariant"
-          is-customer
-          customer-is-hover
-          customer-is-edit
-          :customer="args.customer"
-          :overview-active-tab="args.overviewActiveTab"
-          @change-tab="args.overviewActiveTab = $event"
-        >
-          <template #Box="{ data, key }">
-            <OverviewItem
-              v-for="(field, index) in data.items"
-              :key="data.key + '-' + index"
-              is-transparent
-              :title="field.title"
-              :content="field.content"
-            >
-              <template #content>
-                <div class="text-oc-success-500">{{field.content}}</div>
-              </template>
-            </OverviewItem>
-          </template>
-          <template #BoxInfoTooltip>
-            <div class="p-4">
-              <div class="text-oc-error">Tooltip</div>
-            </div>
-          </template>
-          <template #customer-bottom>
-            <div>Customer Bottom</div>
-          </template>
-        </AdditionalContent>
-      </Theme>
-    `
+  description: 'Grouped overview boxes side-by-side with an optional CustomerCard on the right. Each box group accepts a slot name for fully custom cell rendering.',
+  highlights: [
+    'variant="dynamic"',
+    'boxes — array of { items[], showInfo, slot }',
+    'is-customer + customer — show CustomerCard panel',
+    '#[box.slot]="{ data, key }" — custom box slot',
+    '#customer-bottom — extra content below customer info'
+  ],
+  code: DynamicRaw,
+  render: () => ({
+    components: { DynamicExample, Theme },
+    template: `<Theme class="p-4"><DynamicExample /></Theme>`
   })
 }
 
 export const Balance = {
-  args,
-  argTypes,
-  render: (args) => ({
-    components: { AdditionalContent, Theme },
-    setup() {
-      return { args, argTypes }
-    },
-    template: `
-      <Theme class="h-[300px]">
-        <AdditionalContent
-          :main-link="args.mainLink"
-          :chip-label="args.chipLabel"
-          :additional-title="args.additionalTitle"
-          :chip-variant="args.chipVariant"
-          :user-id="args.userId"
-          :primary-actions="args.primaryActions"
-          variant="balance"
-          :boxes="args.boxes"
-          :overview-items="args.overviewItems"
-          :overview-tabs="args.overviewTabs"
-          :customer-card-variant="args.customerCardVariant"
-          :is-customer="args.isCustomer"
-          :customer="args.customer"
-          :overview-active-tab="args.overviewActiveTab"
-          @change-tab="args.overviewActiveTab = $event"
-        >
-          <template #hitpay="{ tab }">
-            Test block for hitpay slot
-          </template>
-          <template #footer>
-            Test block for footer slot
-          </template>
-        </AdditionalContent>
-      </Theme>
-    `
+  description: 'Financial summary header with tab-switchable balances and a row of metric tiles. Emits change-tab when the user switches tabs.',
+  highlights: [
+    'variant="balance"',
+    'overview-tabs — tab buttons with balance values',
+    'overview-items — metric tiles (icon + title + content)',
+    'overview-active-tab + change-tab — controlled tab state',
+    '#[tab.value] slot — custom content per tab'
+  ],
+  code: BalanceRaw,
+  render: () => ({
+    components: { BalanceExample, Theme },
+    template: `<Theme class="p-4"><BalanceExample /></Theme>`
+  })
+}
+
+export const Expanding = {
+  description: 'Flat grid of key-value items with a "Show more / Show less" toggle. Ideal for transaction detail pages where many fields exist but only the most important should be visible by default. Supports an optional CustomerCard on the right.',
+  highlights: [
+    'variant="expanding"',
+    'expanding-items — flat array of { title, content, info, tooltip, class, button, slot }',
+    'expanding-initial-count — items shown before expanding (default 6)',
+    'expanding-columns — grid columns (default 3)',
+    'is-customer + customer — CustomerCard on the right',
+    '#[item.slot]="{ data }" — custom cell content per item'
+  ],
+  code: ExpandingRaw,
+  render: () => ({
+    components: { ExpandingExample, Theme },
+    template: `<Theme class="p-4"><ExpandingExample /></Theme>`
   })
 }

--- a/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.vue
+++ b/packages/core/src/Elements/AdditionalContent/OcAdditionalContent.vue
@@ -3,6 +3,7 @@ import { Chip, PrimaryActions, Skeleton } from '@/orchidui-core'
 import OcTitle from '@/orchidui-core/Elements/PageTitle/OcTitle.vue'
 import BalanceOverview from './BalanceType/OcBalanceOverview.vue'
 import DynamicType from './DynamicType/OcDynamicType.vue'
+import ExpandingType from './ExpandingType/OcExpandingType.vue'
 
 const props = defineProps({
   /** Base URL prefix shown next to the userId link (e.g. `'https://app.hitpay.com/customers/'`). */
@@ -31,15 +32,21 @@ const props = defineProps({
   customerIsEdit: { type: Boolean, default: false },
   /**
    * Layout variant that controls which child component is rendered.
-   * @values default, dynamic, balance
+   * @values default, dynamic, balance, expanding
    */
   variant: {
     type: String,
     default: 'default',
-    validator: (val) => ['default', 'dynamic', 'balance'].includes(val)
+    validator: (val) => ['default', 'dynamic', 'balance', 'expanding'].includes(val)
   },
   /** Array of box group objects passed to the dynamic variant (each with `items` array of OverviewItem props). */
   boxes: { type: Array, default: () => [] },
+  /** Flat array of item objects for the expanding variant (each with title, content, info, tooltip, class, button, slot). */
+  expandingItems: { type: Array, default: () => [] },
+  /** Number of items visible before "Show more" is clicked (expanding variant only). */
+  expandingInitialCount: { type: Number, default: 6 },
+  /** Number of grid columns in the expanding variant. */
+  expandingColumns: { type: Number, default: 3 },
   /** Show a CustomerCard in the dynamic variant. */
   isCustomer: { type: Boolean, default: false },
   /** Show skeleton placeholders while data is loading. */
@@ -141,6 +148,25 @@ const copyLink = async () => {
         <slot :name="name" v-bind="slotData" />
       </template>
     </DynamicType>
+
+    <ExpandingType
+      v-else-if="variant === 'expanding'"
+      :items="expandingItems"
+      :initial-count="expandingInitialCount"
+      :columns="expandingColumns"
+      :customer-card-variant="customerCardVariant"
+      :customer="customer"
+      :is-customer="isCustomer"
+      :customer-is-hover="customerIsHover"
+      :customer-is-edit="customerIsEdit"
+      :class="additionalStyling"
+      @add-customer="$emit('addCustomer')"
+      @edit-customer="$emit('editCustomer', $event)"
+    >
+      <template v-for="(_, name) in $slots" #[name]="slotData">
+        <slot :name="name" v-bind="slotData" />
+      </template>
+    </ExpandingType>
 
     <BalanceOverview
       v-else-if="variant === 'balance'"

--- a/packages/core/src/Elements/AdditionalContent/examples/Balance.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Balance.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { ref } from 'vue'
+import { AdditionalContent } from '@orchidui/core'
+
+const activeTab = ref('hitpay')
+
+const overviewItems = [
+  { title: 'Total revenue', content: 'SGD 11,170.00', icon: 'coins',    iconProps: { class: 'text-oc-primary' },   isFooter: true },
+  { title: 'This month',    content: 'SGD 1,870.00',  icon: 'coin',     iconProps: { class: 'text-oc-accent-1' } },
+  { title: 'Completed',     content: '20',            icon: 'check',    iconProps: { class: 'text-oc-success' } },
+  { title: 'Refunded',      content: '3',             icon: 'backward', iconProps: { class: 'text-oc-error' } }
+]
+
+const overviewTabs = [
+  { title: 'HitPay Balance', content: 'SGD 1,110.00', value: 'hitpay', countryIso: 'SG' },
+  { title: 'Card Balance',   content: 'SGD 1,000.00', value: 'card' }
+]
+</script>
+
+<template>
+  <AdditionalContent
+    variant="balance"
+    :overview-items="overviewItems"
+    :overview-tabs="overviewTabs"
+    :overview-active-tab="activeTab"
+    @change-tab="activeTab = $event"
+  />
+</template>

--- a/packages/core/src/Elements/AdditionalContent/examples/Default.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Default.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { AdditionalContent } from '@orchidui/core'
+
+const primaryActions = {
+  mainLinkAction: {
+    tooltipContent: 'Preview Link',
+    url: 'https://securecheckout.staging.hit-pay.com/payment-request/@minstore-edit43'
+  },
+  copyTooltipContent: 'Copy payment link',
+  copiedTooltipContent: 'Payment link copied!',
+  actions: [
+    { isCopyButton: true },
+    {
+      icon: 'pencil',
+      tooltipContent: 'Edit',
+      onClick: () => console.log('edit clicked')
+    }
+  ]
+}
+</script>
+
+<template>
+  <AdditionalContent
+    variant="default"
+    main-link="https://securecheckout.staging.hit-pay.com/payment-request"
+    user-id="/@minstore-edit43"
+    additional-title="Premium Store"
+    chip-variant="success"
+    chip-label="Active"
+    :primary-actions="primaryActions"
+  />
+</template>

--- a/packages/core/src/Elements/AdditionalContent/examples/Dynamic.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Dynamic.vue
@@ -1,0 +1,48 @@
+<script setup>
+import { AdditionalContent } from '@orchidui/core'
+
+const customer = {
+  name: 'Alex Turner',
+  email: 'alex@arcticmonkey.io',
+  phone: '+65 8373 3739',
+  address: {
+    street: '123 Main Street',
+    city: 'Pennsylvania',
+    state: 'Pennsylvania',
+    postal_code: '12345',
+    country: 'USA'
+  }
+}
+
+const boxes = [
+  {
+    showInfo: false,
+    items: [
+      { title: 'Purpose',   content: 'Premium GYM membership' },
+      { title: 'ID',        content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+      { title: 'Reference', content: '9a2f500c-545d-4db6-84fa-c40d65146f43' }
+    ]
+  },
+  {
+    showInfo: false,
+    items: [
+      { title: 'Created at', content: '20/11/2023' },
+      { title: 'Expired at', content: '20/12/2023' }
+    ]
+  }
+]
+</script>
+
+<template>
+  <AdditionalContent
+    variant="dynamic"
+    :boxes="boxes"
+    is-customer
+    customer-is-hover
+    customer-is-edit
+    customer-card-variant="big"
+    :customer="customer"
+    @add-customer="console.log('add customer')"
+    @edit-customer="console.log('edit customer', $event)"
+  />
+</template>

--- a/packages/core/src/Elements/AdditionalContent/examples/Dynamic.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Dynamic.vue
@@ -18,8 +18,8 @@ const boxes = [
   {
     showInfo: false,
     items: [
-      { title: 'Purpose',   content: 'Premium GYM membership' },
-      { title: 'ID',        content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+      { title: 'Purpose', content: 'Premium GYM membership' },
+      { title: 'ID', content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
       { title: 'Reference', content: '9a2f500c-545d-4db6-84fa-c40d65146f43' }
     ]
   },

--- a/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { AdditionalContent } from '@orchidui/core'
+
+const customer = {
+  name: 'Alex Turner',
+  email: 'alex@arcticmonkey.io',
+  phone: '+65 8373 3739',
+  address: {
+    street: '123 Main Street',
+    city: 'Pennsylvania',
+    state: 'Pennsylvania',
+    postal_code: '12345',
+    country: 'USA'
+  }
+}
+
+const items = [
+  { title: 'Purpose',    content: 'Premium GYM membership' },
+  { title: 'ID',         content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+  { title: 'Reference',  content: 'REF-20231120-001' },
+  { title: 'Created at', content: '20/11/2023' },
+  { title: 'Expired at', content: '20/12/2023' },
+  { title: 'Status',     content: 'Completed', class: 'text-oc-success' },
+  { title: 'Amount',     content: 'SGD 150.00' },
+  {
+    title: 'Channel',
+    content: 'Point of sale',
+    info: true,
+    tooltip: 'The payment channel used for this transaction'
+  },
+  { title: 'Fee', content: 'SGD 2.50' }
+]
+</script>
+
+<template>
+  <AdditionalContent
+    variant="expanding"
+    :expanding-items="items"
+    :expanding-initial-count="6"
+    is-customer
+    customer-card-variant="big"
+    :customer="customer"
+    @add-customer="console.log('add customer')"
+  />
+</template>

--- a/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { AdditionalContent } from '@orchidui/core'
+import { AdditionalContent } from '@/orchidui-core'
 
 const customer = {
   name: 'Alex Turner',
@@ -15,13 +15,13 @@ const customer = {
 }
 
 const items = [
-  { title: 'Purpose',    content: 'Premium GYM membership' },
-  { title: 'ID',         content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
-  { title: 'Reference',  content: 'REF-20231120-001' },
+  { title: 'Purpose', content: 'Premium GYM membership' },
+  { title: 'ID', content: '9a2f500c-545d-4db6-84fa-c40d65146f43' },
+  { title: 'Reference', content: 'REF-20231120-001' },
   { title: 'Created at', content: '20/11/2023' },
   { title: 'Expired at', content: '20/12/2023' },
-  { title: 'Status',     content: 'Completed', class: 'text-oc-success' },
-  { title: 'Amount',     content: 'SGD 150.00' },
+  { title: 'Status', content: 'Completed', class: 'text-oc-success' },
+  { title: 'Amount', content: 'SGD 150.00' },
   {
     title: 'Channel',
     content: 'Point of sale',

--- a/packages/core/src/Elements/AdditionalContent/examples/ExpandingCustomerInfo.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/ExpandingCustomerInfo.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { AdditionalContent } from '@/orchidui-core'
+
+const customer = {
+  created_at: '2023-11-20T00:00:00Z',
+  phone_number_country_code: '65',
+  phone_number: '8373 3739',
+  email: 'alex@arcticmonkey.io',
+  address_line: '123 Main Street, Pennsylvania, PA 12345, USA',
+  remark: 'VIP customer — priority support'
+}
+
+const formatDate = (date) => (date ? new Date(date).toLocaleDateString('en-GB') : '—')
+
+const fullPhoneNumber = customer.phone_number_country_code
+  ? `+${customer.phone_number_country_code} ${customer.phone_number}`
+  : customer.phone_number || '-'
+
+const items = [
+  { title: 'CREATED AT', content: formatDate(customer.created_at) },
+  { title: 'PHONE NUMBER', content: fullPhoneNumber },
+  { title: 'EMAIL', content: customer.email || '-' },
+  { title: 'ADDRESS', content: customer.address_line || '-', colSpan: 2 },
+  ...(customer.remark ? [{ title: 'REMARKS', content: customer.remark }] : [])
+]
+</script>
+
+<template>
+  <AdditionalContent
+    variant="expanding"
+    :expanding-items="items"
+    :expanding-columns="3"
+    :expanding-initial-count="6"
+  />
+</template>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.91.0",
+    "@orchidui/core": "1.92.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.90.0",
+    "@orchidui/core": "1.91.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.89.0",
+    "@orchidui/core": "1.90.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/src/Dashboard/TextEditor/snow.css
+++ b/packages/dashboard/src/Dashboard/TextEditor/snow.css
@@ -830,14 +830,12 @@
   font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
   padding: 8px;
 }
-.has-error {
-  .ql-toolbar.ql-snow {
-    border-color: #dc3545;
-    border-bottom: 1px solid #d1d5db;
-  }
-  .ql-container.ql-snow {
-    border-color: #dc3545;
-  }
+.has-error .ql-toolbar.ql-snow {
+  border-color: #dc3545;
+  border-bottom: 1px solid #d1d5db;
+}
+.has-error .ql-container.ql-snow {
+  border-color: #dc3545;
 }
 .ql-toolbar.ql-snow .ql-formats {
   margin-right: 15px;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an “expanding” variant to `AdditionalContent`: a flat grid with show more/less, item tooltips and colSpan, an optional right-side `CustomerCard`, and a mobile slide-over details panel — aligned with HIT-17564’s customer/transaction header. Updates Storybook with a Playground and focused examples; upgrades `@orchidui/core` and `@orchidui/dashboard` to 1.92.0.

- **New Features**
  - Added `OcExpandingType.vue` and `MobileExpandingType.vue`; wired into `OcAdditionalContent.vue` as `variant="expanding"` with `expandingItems`, `expandingInitialCount` (default 6), and `expandingColumns` (default 3). Emits `addCustomer`/`editCustomer`; supports per-item `slot`, `info` tooltip, `button`, and `colSpan`. Auto-expands the last item to fill incomplete rows.
  - Mobile: preview grid respects `columns`, “See details” opens a slide-in panel. Storybook: new Playground and examples (`Default`, `Dynamic`, `Balance`, `Expanding`, `ExpandingCustomerInfo`).

- **Bug Fixes**
  - Expanding: fixed show more/less toggle and right/bottom grid borders; improved mobile toggle clickability (z-index/spacing).
  - Dashboard text editor: flattened `.has-error` CSS selectors so Quill Snow borders render correctly.

<sup>Written for commit e04694323d0e46714cb47b59e21505dd070b668c. Summary will update on new commits. <a href="https://cubic.dev/pr/hit-pay/orchid/pull/1256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

