### PR TITLE
fix mobile expanding type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.92.0",
+      "version": "1.93.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.92.0",
+      "version": "1.93.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.92.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.92.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.92.0.tgz",
+      "integrity": "sha512-PxTsBp7dgZYSNFiidUxeHViSpB7PAtX0HYwJ/XgGT9H9mVpOQ/GT4MUEtrnihDnS3b974hryJm92ruWV8xLK+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.93.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.92.0",
+        "@orchidui/core": "1.93.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.92.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.92.0.tgz",
-      "integrity": "sha512-PxTsBp7dgZYSNFiidUxeHViSpB7PAtX0HYwJ/XgGT9H9mVpOQ/GT4MUEtrnihDnS3b974hryJm92ruWV8xLK+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.92.0",
+  "version": "1.93.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/MobileExpandingType.vue
@@ -55,7 +55,15 @@ const getEffectiveColSpan = (item, index) => {
 <template>
   <div>
     <div class="flex flex-col bg-oc-gray-50 border border-oc-gray-200 rounded overflow-hidden">
-      <div :class="`grid grid-cols-${columns}`">
+      <div
+        class="grid"
+        :class="{
+          'grid-cols-1': columns === 1,
+          'grid-cols-2': columns === 2,
+          'grid-cols-3': columns === 3,
+          'grid-cols-4': columns === 4,
+        }"
+      >
         <div
           v-for="(item, i) in previewItems"
           :key="i"

--- a/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
+++ b/packages/core/src/Elements/AdditionalContent/ExpandingType/OcExpandingType.vue
@@ -81,11 +81,29 @@ const getEffectiveColSpan = (item, index) => {
 
   <!-- Desktop -->
   <div class="hidden md:flex md:flex-row bg-oc-gray-50 border border-oc-gray-200 rounded">
-    <div class="relative flex-1" :class="[`grid grid-cols-${columns}`, hasMore ? 'md:mb-0' : '']">
+    <div
+      class="relative flex-1 grid"
+      :class="[
+        {
+          'grid-cols-1': columns === 1,
+          'grid-cols-2': columns === 2,
+          'grid-cols-3': columns === 3,
+          'grid-cols-4': columns === 4
+        },
+        hasMore ? 'md:mb-0' : ''
+      ]"
+    >
       <div
         v-for="(item, index) in visibleItems"
         :key="index"
-        :class="[getBorderClasses(index), { 'cursor-pointer': typeof item.onClick === 'function' }, { 'col-span-2': getEffectiveColSpan(item, index) === 2, 'col-span-3': getEffectiveColSpan(item, index) === 3 }]"
+        :class="[
+          getBorderClasses(index),
+          { 'cursor-pointer': typeof item.onClick === 'function' },
+          {
+            'col-span-2': getEffectiveColSpan(item, index) === 2,
+            'col-span-3': getEffectiveColSpan(item, index) === 3
+          }
+        ]"
         class="p-4 flex flex-col gap-y-1 group"
         @click="item.onClick?.()"
       >
@@ -102,11 +120,7 @@ const getEffectiveColSpan = (item, index) => {
         </div>
 
         <slot v-if="item.slot && $slots[item.slot]" :name="item.slot" :data="item" />
-        <div
-          v-else
-          class="overflow-hidden text-ellipsis flex items-center"
-          :class="item.class"
-        >
+        <div v-else class="overflow-hidden text-ellipsis flex items-center" :class="item.class">
           <span>{{ item.content }}</span>
           <Button
             v-if="item.button"
@@ -116,7 +130,10 @@ const getEffectiveColSpan = (item, index) => {
         </div>
       </div>
 
-      <div v-if="hasMore" class="absolute -bottom-8 right-0 w-full justify-center flex items-center z-10">
+      <div
+        v-if="hasMore"
+        class="absolute -bottom-8 right-0 w-full justify-center flex items-center z-10"
+      >
         <div
           class="rounded-b border cursor-pointer border-oc-gray-200 h-[28px] text-oc-primary hover:text-oc-text-400 px-3 py-2 gap-x-2 flex items-center"
           @click="isExpanded = !isExpanded"
@@ -127,7 +144,10 @@ const getEffectiveColSpan = (item, index) => {
       </div>
     </div>
 
-    <div v-if="isCustomer" class="flex bg-oc-accent-1-50 flex-col md:border-l border-oc-gray-200 md:max-w-[250px] shrink-0 w-full md:rounded-r">
+    <div
+      v-if="isCustomer"
+      class="flex bg-oc-accent-1-50 flex-col md:border-l border-oc-gray-200 md:max-w-[250px] shrink-0 w-full md:rounded-r"
+    >
       <CustomerCard
         :variant="customerCardVariant"
         :customer="customer"

--- a/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/Expanding.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { AdditionalContent } from '@/orchidui-core'
+import { AdditionalContent } from '@orchidui/core'
 
 const customer = {
   name: 'Alex Turner',

--- a/packages/core/src/Elements/AdditionalContent/examples/ExpandingCustomerInfo.vue
+++ b/packages/core/src/Elements/AdditionalContent/examples/ExpandingCustomerInfo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { AdditionalContent } from '@/orchidui-core'
+import { AdditionalContent } from '@orchidui/core'
 
 const customer = {
   created_at: '2023-11-20T00:00:00Z',

--- a/packages/core/src/Elements/PageTitle/OcPageTitleRight.vue
+++ b/packages/core/src/Elements/PageTitle/OcPageTitleRight.vue
@@ -17,17 +17,18 @@ const { isMobile } = useWindowWidth()
 const clickAdditional = (e) => {
   e.preventDefault()
   isDropdownOpened.value = !isDropdownOpened.value
-  const { secondaryButtonProps } = props;
-  typeof secondaryButtonProps?.['onAdditionClick'] === 'function' && secondaryButtonProps['onAdditionClick']();
+  const { secondaryButtonProps } = props
+  typeof secondaryButtonProps?.['onAdditionClick'] === 'function' &&
+    secondaryButtonProps['onAdditionClick'](e)
 }
 const clickSecondaryButton = (e) => {
-  const { secondaryButtonProps } = props;
+  const { secondaryButtonProps } = props
   if (secondaryButtonProps.additionalAreaIcon && secondaryButtonProps.dropdownOptions) {
     // need to stop to prevent open dropdown, dropdown should be triggerred on additional icon.
     e.stopPropagation()
     e.preventDefault()
 
-    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e);
+    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e)
 
     return
   }
@@ -36,7 +37,7 @@ const clickSecondaryButton = (e) => {
     e.stopPropagation()
     e.preventDefault()
 
-    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e);
+    typeof secondaryButtonProps.onClick === 'function' && secondaryButtonProps.onClick(e)
   }
 }
 </script>
@@ -85,7 +86,6 @@ const clickSecondaryButton = (e) => {
   <div v-else class="flex gap-x-3 items-center">
     <Skeleton class="w-[100px] h-[36px] rounded" />
     <Skeleton class="w-[100px] h-[36px] rounded" />
-
   </div>
 </template>
 <style scoped lang="scss">

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.92.0",
+  "version": "1.93.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.92.0",
+    "@orchidui/core": "1.93.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes ExpandingType grid layout by switching to explicit `grid-cols-1`–`grid-cols-4` in both `MobileExpandingType` and `OcExpandingType`, and updates `OcPageTitleRight` to pass events and stop propagation to avoid accidental dropdown opens.
Updates examples to import `@orchidui/core` and bumps `@orchidui/core` and `@orchidui/dashboard` to 1.93.0.

<sup>Written for commit 9c96c7f9d5eee053073c31b8017b1121b673cc72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

