### PR TITLE
[Feature-fix] Fix table data status & tab same value

### DIFF
--- a/packages/core/src/DataTable/OcDataTable.stories.js
+++ b/packages/core/src/DataTable/OcDataTable.stories.js
@@ -95,7 +95,7 @@ export const Playground = {
     components: { DataTable, Button },
     setup() {
       const selected = ref([])
-      const filter   = ref({ page: 1, per_page: 10, tab: '', keywords: '' })
+      const filter   = ref({ page: 1, per_page: 10, tab: '', keywords: '', statuses: undefined })
       const lastClickedRow = ref(null)
 
       const rows = [
@@ -121,6 +121,7 @@ export const Playground = {
           ...(args.showTabs && {
             tabs: {
               key: 'tab',
+              filter_name: 'statuses',
               options: [
                 { label: 'All',      value: '' },
                 { label: 'Active',   value: 'active' },
@@ -140,6 +141,30 @@ export const Playground = {
                     { label: 'Free',       value: 'free' },
                     { label: 'Pro',        value: 'pro' },
                     { label: 'Enterprise', value: 'enterprise' }
+                  ]
+                }
+              },
+              {
+                name: 'statuses',
+                type: 'Select',
+                props: {
+                  label: 'Status',
+                  placeholder: 'Select status',
+                  isCheckboxes: true,
+                  isSelectAll: true,
+                  multiple: true,
+                  popperOptions: { strategy: 'fixed' },
+                  options: [
+                    { label: 'Draft', value: 'draft', variant: 'gray' },
+                    { label: 'Pending', value: 'pending', variant: 'warning' },
+                    { label: 'Need Approval', value: 'need_approval', variant: 'accent-2' },
+                    { label: 'Scheduled', value: 'scheduled', variant: 'dark-blue' },
+                    { label: 'Processing', value: 'processing', variant: 'primary' },
+                    { label: 'Completed', value: 'completed', variant: 'success' },
+                    { label: 'Failed', value: 'failed', variant: 'error' },
+                    { label: 'Rejected', value: 'rejected', variant: 'light-red' },
+                    { label: 'Canceled', value: 'canceled', variant: 'neutral' },
+                    { label: 'File Processing', value: 'file_processing', variant: 'accent-3' }
                   ]
                 }
               }

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -269,11 +269,15 @@ const changeSearchKey = (value) => {
 const clearAllFilters = () => {
   searchQueries.value = []
   activeFilterTab.value = ''
+  const activeTab = filterOptions.value?.tabs?.filter_name
+    ? defaultFilterData[filterOptions.value?.tabs?.key]
+    : activeFilterTab.value
+
   filterData.value = clearAllFiltersUtil(
     filterData.value,
     filterOptions.value,
     itemsPerPage.value,
-    activeFilterTab.value
+    activeTab
   )
   applyFilter()
 }
@@ -307,6 +311,15 @@ const applyFilter = (
   if (filterOptions.value?.tabs && isChangeTab) {
     filterData.value[filterOptions.value.tabs.key] = activeFilterTab.value
   }
+  // need to sync with filter data if same key with tabs
+  if (filterOptions.value?.tabs?.filter_name) {
+    if (isChangeTab) {
+      filterData.value[filterOptions.value?.tabs?.filter_name] = null
+    } else if(filterFormData) {
+      activeFilterTab.value = null
+    }
+  }
+
   if (filterOptions.value?.search) {
     if (filterOptions.value.search?.options?.length) {
       Object.keys(filterData.value).forEach((key) => {
@@ -335,7 +348,10 @@ const applyFilter = (
   }
 
   let filterTabKey = filterOptions.value?.tabs?.key
-  if (filterTabKey && activeFilterTab.value !== filterData.value[filterTabKey]) {
+  if (filterTabKey &&
+    activeFilterTab.value !== filterData.value[filterTabKey] &&
+    !filterOptions.value?.tabs?.filter_name
+  ) {
     const selectedTab = filterOptions.value.tabs?.options?.find(
       (option) => option.value?.toString() === filterData.value[filterTabKey]?.toString()
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `DataTable` filter desync when tabs and filters target the same value, and adds `tabs.filter_name` to link a tab group to a filter key. Addresses Linear HIT-17722.

- **Bug Fixes**
  - Sync tab and filter when `tabs.filter_name` is set (tab change clears linked filter; filter change clears tab).
  - Adjust clear/apply flows to respect linked tabs and avoid unintended tab resets.

- **New Features**
  - Support `tabs.filter_name` to bind tabs to an existing filter key (e.g., `statuses`).
  - Storybook: add `statuses` multi-select filter and include it in the initial filter object.

<sup>Written for commit 378a036ff2447e078fc929012931f7508d65e54d. Summary will update on new commits. <a href="https://cubic.dev/pr/hit-pay/orchid/pull/1259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

