### PR TITLE
HIT-17757 customize pie cart label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.93.0",
+      "version": "1.94.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.93.0",
+      "version": "1.94.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.93.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.93.0.tgz",
+      "integrity": "sha512-qofXKusXqF0r5uGYJCNfUb9NPCYn5sPjmIc5IQNBKeZWEPx0CtrFBRKZDM/5XxAR2TkB/dUpnrHXfAF5Wo65/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.93.0",
+    "@orchidui/core": "1.94.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
@@ -14,6 +14,25 @@ export const Default = {
       { value: 200, name: 'Paynow', itemStyle: { color: '#AEC5FF' } },
       { value: 100, name: 'Others', itemStyle: { color: '#86FFCC' } }
     ],
+    tooltip: {
+      show: true,
+      trigger: 'item',
+      padding: 0,
+      formatter: (params) => `
+        <div class="py-3 px-4 leading-normal">
+          <div class="uppercase text-[10px] font-medium text-oc-text-400">
+            ${params.name}
+          </div>
+          <div class="text-oc-text-500 font-medium text-base">
+            SGD ${Number(params.value).toLocaleString('en-US', {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2
+            })}
+            (${params.percent}%)
+          </div>
+        </div>
+      `
+    },
     showPercentInLabel: true,
     totalLabel: 'Total Customer'
   },

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
@@ -13,7 +13,9 @@ export const Default = {
       { value: 1048, name: 'Cards', itemStyle: { color: '#356DFF' } },
       { value: 200, name: 'Paynow', itemStyle: { color: '#AEC5FF' } },
       { value: 100, name: 'Others', itemStyle: { color: '#86FFCC' } }
-    ]
+    ],
+    showPercentInLabel: true,
+    totalLabel: 'Total Customer'
   },
   render: (args) => ({
     components: { OcOverviewPieChart, Theme },

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
@@ -1,31 +1,32 @@
 <template>
   <div class="flex flex-col items-center justify-center">
     <div class="relative w-[210px] h-[210px]">
-    <div ref="pieChart" class="w-[210px] h-[210px]" />
+      <div ref="pieChart" class="w-[210px] h-[210px]" />
 
-    <!-- Custom center label overlay -->
-    <div class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-      <div class="text-center">
-        <div class="text-oc-text-400">{{ centerLabel }}</div>
-        <div class="text-lg font-semibold font-reddit-mono">{{ currency }} {{ formatCurrency(centerValue) }}</div>
+      <!-- Custom center label overlay -->
+      <div class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <div class="text-center">
+          <div class="text-oc-text-400">{{ centerLabel }}</div>
+          <div class="text-lg font-semibold font-reddit-mono">
+            {{ currency }} {{ formatCurrency(centerValue) }}
+          </div>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- Custom legend below the chart -->
-  <div v-if="chartData && chartData.length > 0" class="mt-4 flex flex-wrap gap-3 justify-center">
-    <div
-      v-for="(item, index) in chartData"
-      :key="index"
-      class="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
-    >
+    <!-- Custom legend below the chart -->
+    <div v-if="chartData && chartData.length > 0" class="mt-4 flex flex-wrap gap-3 justify-center">
       <div
-        class="w-3 h-3 rounded-full"
-        :style="{ backgroundColor: getLegendColor(index) }"
-      ></div>
-      <span class="text-sm">{{ item.name }}</span>
+        v-for="(item, index) in chartData"
+        :key="index"
+        class="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+      >
+        <div class="w-3 h-3 rounded-full" :style="{ backgroundColor: getLegendColor(index) }"></div>
+        <span class="text-sm"
+          >{{ item.name }} {{ showPercentInLabel ? `(${formatPercentage(item.value)}%)` : '' }}
+        </span>
+      </div>
     </div>
-  </div>
   </div>
 </template>
 
@@ -44,6 +45,14 @@ const props = defineProps({
     type: Object,
     default: () => ({})
   },
+  totalLabel: {
+    type: String,
+    default: 'Total'
+  },
+  showPercentInLabel: {
+    type: Boolean,
+    default: false
+  }
 })
 
 // Reactive state for center label
@@ -74,50 +83,52 @@ const totalValue = computed(() => {
 
 // Initialize center label with total
 const initializeCenterLabel = () => {
-  centerLabel.value = 'Total'
+  centerLabel.value = props.totalLabel
   centerValue.value = totalValue.value
 }
 
 // Chart options
 const chartOptions = computed(() => ({
   tooltip: props.tooltip,
-  series: [{
-    id: 'overviewPieChart',
-    data: props.chartData || [],
-    type: 'pie',
-    radius: ['80%', '100%'],
-    avoidLabelOverlap: false,
+  series: [
+    {
+      id: 'overviewPieChart',
+      data: props.chartData || [],
+      type: 'pie',
+      radius: ['80%', '100%'],
+      avoidLabelOverlap: false,
 
-    itemStyle: {
-      borderRadius: 6,
-      borderColor: '#fff',
-      borderWidth: 2
-    },
-    animation: false,
-    label: {
-      show: false, // Hide default labels
-    },
-    labelLine: {
-      show: false
-    },
-    // Emphasize hovered/active slice and blur others to gray
-    emphasis: {
-      scale: false,
-      focus: 'self',
-      label: { show: false },
       itemStyle: {
-        color: 'inherit',
-      }
-    },
-    blur: {
-      itemStyle: {
-        color: '#F2F2F4',
-        opacity: 1,
+        borderRadius: 6,
+        borderColor: '#fff',
+        borderWidth: 2
       },
-      label: { show: false }
-    },
-    ...(props.additionalOptions ? props.additionalOptions : {})
-  }]
+      animation: false,
+      label: {
+        show: false // Hide default labels
+      },
+      labelLine: {
+        show: false
+      },
+      // Emphasize hovered/active slice and blur others to gray
+      emphasis: {
+        scale: false,
+        focus: 'self',
+        label: { show: false },
+        itemStyle: {
+          color: 'inherit'
+        }
+      },
+      blur: {
+        itemStyle: {
+          color: '#F2F2F4',
+          opacity: 1
+        },
+        label: { show: false }
+      },
+      ...(props.additionalOptions ? props.additionalOptions : {})
+    }
+  ]
 }))
 
 // Chart instance
@@ -126,8 +137,6 @@ const { chart } = useChart(pieChart, chartOptions)
 
 // Legend functions
 const getLegendColor = (index) => props.chartData[index].itemStyle.color
-
-
 
 // Initialize center label when chart is ready
 watch(chart, async (newChart) => {
@@ -148,16 +157,20 @@ watch(chart, async (newChart) => {
 
     newChart.on('mouseout', 'series', () => {
       // Reset to total when not hovering
-      centerLabel.value = 'Total'
+      centerLabel.value = props.totalLabel
       centerValue.value = totalValue.value
     })
   }
 })
 
 // Watch for data changes to update total
-watch(() => props.chartData, () => {
-  if (chart.value) {
-    initializeCenterLabel()
-  }
-}, { deep: true })
+watch(
+  () => props.chartData,
+  () => {
+    if (chart.value) {
+      initializeCenterLabel()
+    }
+  },
+  { deep: true }
+)
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Overview pie chart to show a clear, customizable Total in the center and optional percentages in the legend for the cart popup. Supports HIT-17720 by clarifying the total amount shown in the popup.

- **Bug Fixes**
  - Applied `additionalOptions` to the pie series correctly so custom series config works.
  - Center label reset now uses the `totalLabel` prop instead of a hardcoded value.

- **Dependencies**
  - Bumped `@orchidui/core` and `@orchidui/dashboard` to 1.94.0.
  - Updated `@orchidui/dashboard` to depend on `@orchidui/core@1.94.0`.

<sup>Written for commit 98cb7b0bd9543eba60c0c44b821892b21813d9af. Summary will update on new commits. <a href="https://cubic.dev/pr/hit-pay/orchid/pull/1260?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

