### PR TITLE
fix display total in pie chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.94.0",
+      "version": "1.95.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.94.0",
+      "version": "1.95.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.93.0",
+        "@orchidui/core": "1.94.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.93.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.93.0.tgz",
-      "integrity": "sha512-qofXKusXqF0r5uGYJCNfUb9NPCYn5sPjmIc5IQNBKeZWEPx0CtrFBRKZDM/5XxAR2TkB/dUpnrHXfAF5Wo65/w==",
+      "version": "1.94.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.94.0.tgz",
+      "integrity": "sha512-kFSLkpBJLAFIEUeteh88kFnwcOmnTS30eGITEuiof/QNCmdo/0rGci2ZJldLv9auqgC3pZOm3FiMHiB+NQazpA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.94.0",
+  "version": "1.95.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.94.0",
+  "version": "1.95.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.94.0",
+    "@orchidui/core": "1.95.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.stories.js
@@ -8,30 +8,14 @@ export default {
 
 export const Default = {
   args: {
-    currency: 'SGD',
+    currency: '',
     chartData: [
       { value: 1048, name: 'Cards', itemStyle: { color: '#356DFF' } },
       { value: 200, name: 'Paynow', itemStyle: { color: '#AEC5FF' } },
       { value: 100, name: 'Others', itemStyle: { color: '#86FFCC' } }
     ],
     tooltip: {
-      show: true,
-      trigger: 'item',
-      padding: 0,
-      formatter: (params) => `
-        <div class="py-3 px-4 leading-normal">
-          <div class="uppercase text-[10px] font-medium text-oc-text-400">
-            ${params.name}
-          </div>
-          <div class="text-oc-text-500 font-medium text-base">
-            SGD ${Number(params.value).toLocaleString('en-US', {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2
-            })}
-            (${params.percent}%)
-          </div>
-        </div>
-      `
+      show: false
     },
     showPercentInLabel: true,
     totalLabel: 'Total Customer'

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
@@ -62,10 +62,10 @@ const centerValue = ref(0)
 // Utility functions
 const formatCurrency = (value) => {
   const numValue = typeof value === 'number' ? value : Number(value)
-  return numValue.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  })
+  return numValue.toLocaleString('en-US', props.currency
+    ? { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+    : { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+  )
 }
 
 // Calculate percentage of a value against total


### PR DESCRIPTION
@

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pie chart total formatting to show whole numbers when no currency is set. This makes the OverviewPieChart work correctly for non-currency data.

- **Bug Fixes**
  - Updated format logic in OcOverviewPieChart to use 0 decimals when `currency` is empty; keeps 2 decimals when set.
  - Story now defaults `currency` to an empty string and disables tooltip to reflect non-currency usage.

- **Dependencies**
  - Bump `@orchidui/core` and `@orchidui/dashboard` to `1.95.0`; update dashboard’s dependency on `@orchidui/core` to `1.95.0`.

<sup>Written for commit 4b02964a38cadcbccb0aa00ce62197f6b66034e5. Summary will update on new commits. <a href="https://cubic.dev/pr/hit-pay/orchid/pull/1261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

