### PR TITLE
fix filter form action button make it sticky bottom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.95.0",
+      "version": "1.96.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.95.0",
+      "version": "1.96.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.94.0",
+        "@orchidui/core": "1.95.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.94.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.94.0.tgz",
-      "integrity": "sha512-kFSLkpBJLAFIEUeteh88kFnwcOmnTS30eGITEuiof/QNCmdo/0rGci2ZJldLv9auqgC3pZOm3FiMHiB+NQazpA==",
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.95.0.tgz",
+      "integrity": "sha512-+ZuUrpKCkA2ABCXUOd/8gaizVPEtEXMZU4d9PifHcEqHAFS0GH6Hu/0c+X+9gSx3jyrNYuWA67RjzOlBRirNrQ==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -315,7 +315,7 @@ const applyFilter = (
   if (filterOptions.value?.tabs?.filter_name) {
     if (isChangeTab) {
       filterData.value[filterOptions.value?.tabs?.filter_name] = null
-    } else if(filterFormData) {
+    } else if (filterFormData) {
       activeFilterTab.value = null
     }
   }
@@ -348,7 +348,8 @@ const applyFilter = (
   }
 
   let filterTabKey = filterOptions.value?.tabs?.key
-  if (filterTabKey &&
+  if (
+    filterTabKey &&
     activeFilterTab.value !== filterData.value[filterTabKey] &&
     !filterOptions.value?.tabs?.filter_name
   ) {
@@ -457,6 +458,7 @@ onMounted(() => {
                 :distance="9"
                 placement="bottom-end"
                 is-attach-to-body
+                :max-menu-height="500"
                 @update:model-value="$emit('filter-open', $event)"
               >
                 <Button

--- a/packages/core/src/DataTable/OcFilterForm.vue
+++ b/packages/core/src/DataTable/OcFilterForm.vue
@@ -94,14 +94,14 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex w-[326px] flex-col gap-y-5">
+  <div class="flex w-[326px] flex-col">
     <slot
       :errors="errorsData"
       :values="valuesData"
       :json-form="jsonForm"
       :update-form="onUpdateForm"
     >
-      <div class="max-h-[500px] overflow-y-auto p-5">
+      <div class="p-5">
         <FormBuilder
           :id="`filter-form-${id}`"
           class="grid gap-5"
@@ -114,7 +114,7 @@ onMounted(() => {
       </div>
     </slot>
 
-    <div class="flex gap-x-5 px-5 pb-5">
+    <div class="sticky bottom-0 flex gap-x-5 bg-oc-bg-light px-5 pb-5 pt-3">
       <Button
         class="w-full"
         variant="secondary"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.95.0",
+    "@orchidui/core": "1.96.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limits the DataTable filter dropdown to the viewport and keeps its actions visible, so long filter forms don’t overflow and the buttons are always accessible. Addresses HIT-17603 review feedback on filter usability across Transaction, Order, Invoice, and Payment tables.

- **Bug Fixes**
  - Constrain filter popover height to the viewport; content scrolls inside the menu instead of the form.
  - Make the filter footer actions sticky at the bottom of the dropdown.

- **Dependencies**
  - Bump `@orchidui/core` and `@orchidui/dashboard` to `1.96.0`.

<sup>Written for commit d02da3cf31b5633bf4c00a47ae29309e814d8625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

