### PR TITLE
update sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,33 +11181,16 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.95.0",
+        "@orchidui/core": "1.97.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.95.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.95.0.tgz",
-      "integrity": "sha512-+ZuUrpKCkA2ABCXUOd/8gaizVPEtEXMZU4d9PifHcEqHAFS0GH6Hu/0c+X+9gSx3jyrNYuWA67RjzOlBRirNrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Elements/Sidebar/HitpaySidebar.sample.js
+++ b/packages/core/src/Elements/Sidebar/HitpaySidebar.sample.js
@@ -31,7 +31,6 @@ export const PAYMENT_SIDEBAR_ITEMS = [
     label: 'Bank Payouts',
     children: [
       {
-        active: true,
         name: 'reports-hit-pay-balance',
         path: 'balance',
         label: 'HitPay Balance'
@@ -195,7 +194,6 @@ export const POS_SIDEBAR_ITEMS = [
     label: 'Products',
     children: [
       {
-        active: true,
         name: 'all-products',
         path: 'products',
         label: 'All Products'
@@ -263,7 +261,7 @@ export const POS_SIDEBAR_OTHERS_SIDEBAR_ITEMS = [
 export const POS_SIDEBAR_GROUP = [
   {
     name: 'point-of-sale',
-    label: 'POINT OF SALE',
+    label: 'Point of Sale',
     items: POS_SIDEBAR_ITEMS
   },
   {
@@ -299,7 +297,6 @@ export const ONLINE_STORE_SIDEBAR_ITEMS = [
     label: 'Products',
     children: [
       {
-        active: true,
         name: 'all-products',
         path: 'products',
         label: 'All Products'
@@ -400,7 +397,7 @@ export const ONLINE_STORE_OTHERS_SIDEBAR_ITEMS = [
 export const ONLINE_STORE_SIDEBAR_GROUP = [
   {
     name: 'online-store',
-    label: 'ONLINE STORE',
+    label: 'Online Store',
     items: ONLINE_STORE_SIDEBAR_ITEMS
   },
   {

--- a/packages/core/src/Elements/Sidebar/OcAccountSetup.vue
+++ b/packages/core/src/Elements/Sidebar/OcAccountSetup.vue
@@ -29,7 +29,7 @@ defineProps({
   >
     <div v-if="isExpanded" class="p-3 bg-white rounded-[6px] w-full flex flex-col gap-y-5">
       <template v-if="isPending">
-        <div class="p-2 flex gap-3">
+        <div class="p-2 flex gap-3 items-center">
           <div class="p-3 rounded-full border border-oc-warning-500">
             <OcIcon name="alert" width="20" height="20" class="text-oc-warning-500" />
           </div>

--- a/packages/core/src/Elements/Sidebar/OcAccountSetup.vue
+++ b/packages/core/src/Elements/Sidebar/OcAccountSetup.vue
@@ -68,7 +68,7 @@ defineProps({
       </template>
     </div>
     <div v-else class="bg-white rounded-full p-1">
-      <div v-if="isPending" class="p-3 rounded-full">
+      <div v-if="isPending" class="p-2 rounded-full">
         <oc-icon name="alert" width="20" height="20" class="text-oc-warning-500" />
       </div>
       <div v-else class="pie-wrapper progress style-2">

--- a/packages/core/src/Elements/Sidebar/OcSidebar.js
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.js
@@ -1,4 +1,5 @@
 import Sidebar from './OcSidebar.vue'
+import SidebarContent from './OcSidebarContent.vue'
 import SidebarSubmenu from './OcSidebarSubmenu.vue'
 import AccountSetup from './OcAccountSetup.vue'
 import SidebarHead from './OcSidebarHead.vue'
@@ -8,14 +9,15 @@ import SidebarFooter from './OcSidebarFooter.vue'
 import SidebarFeatureBanners from './OcSidebarFeatureBanners.vue'
 import AccountSetupProgress from './OcAccountSetupProgress.vue'
 
-export { 
-  Sidebar, 
-  SidebarSubmenu, 
-  AccountSetup, 
-  SidebarHead, 
-  SideBarMenu, 
-  SidebarSubMenuItem, 
-  SidebarFooter, 
-  SidebarFeatureBanners, 
-  AccountSetupProgress 
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarSubmenu,
+  AccountSetup,
+  SidebarHead,
+  SideBarMenu,
+  SidebarSubMenuItem,
+  SidebarFooter,
+  SidebarFeatureBanners,
+  AccountSetupProgress
 }

--- a/packages/core/src/Elements/Sidebar/OcSidebar.stories.js
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.stories.js
@@ -99,7 +99,7 @@ export const Default = {
               </Dropdown>
             </template>
           </Sidebar>
-          <div class="w-[calc(100%-300px)]">Content test 1</div>
+          <div class="w-[calc(100%-220px)]">Content test 1</div>
         </div>
       </Theme>
     `

--- a/packages/core/src/Elements/Sidebar/OcSidebar.stories.js
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.stories.js
@@ -20,17 +20,21 @@ export default {
   component: Sidebar,
   tags: ['autodocs'],
   kind: 'composite',
-  use_for: [
-    'app navigation',
-    'main sidebar menu',
-    'side navigation with submenus'
-  ],
-  understand_with: ['SideBarMenu', 'SidebarSubmenu', 'SidebarFooter', 'SidebarFeatureBanners', 'AccountSetupProgress', 'Icon']
+  use_for: ['app navigation', 'main sidebar menu', 'side navigation with submenus'],
+  understand_with: [
+    'SideBarMenu',
+    'SidebarSubmenu',
+    'SidebarFooter',
+    'SidebarFeatureBanners',
+    'AccountSetupProgress',
+    'Icon'
+  ]
 }
 
 export const Default = {
   args: {
     isExpanded: true,
+    isHoverSidebar: false,
     payment_sidebar_menu: PAYMENTS_SIDEBAR_GROUP,
     pos_sidebar_menu: POS_SIDEBAR_GROUP,
     online_store_sidebar_menu: ONLINE_STORE_SIDEBAR_GROUP,
@@ -53,46 +57,50 @@ export const Default = {
     },
     template: `
       <Theme class="layout-payment mb-8">
-        <Sidebar
-          :title="args.title"
-          :sidebar-menu="args.payment_sidebar_menu"
-          :isExpanded="args.isExpanded"
-          @changeExpanded="args.isExpanded = $event"
-        >
-          <template #banner>
-            <AccountSetupProgress :value="args.progress" info-label="Add your bank account" />
-            <SidebarFeatureBanners
-              title="Late invoice fee"
-              is-stacked
-              description="You can now automate late fees on unpaid invoices by setting a fixed amount or percentage of the total, applied after a custom grace period."
-            />
-          </template>
-          <template #before>
-            <OcAccountSetup :isExpanded="args.isExpanded" :progress="args.progress"/>
-          </template>
-          <template #user>
-            <Dropdown v-model="rightMenuDropdown" placement="bottom-end" :distance="10">
-              <Avatar class="uppercase cursor-pointer" :size="32">
-                J
-              </Avatar>
-              <template #menu>
-                <div class="flex flex-col">
-                  <div class="p-2 border-b border-gray-200">
-                    <a href="#">
-                      <DropdownItem text="userName" />
-                    </a>
-                    <a href="#">
-                      <DropdownItem text="Security" />
-                    </a>
+          <div class="flex w-full">
+            <Sidebar
+            :title="args.title"
+            :sidebar-menu="args.payment_sidebar_menu"
+            :isExpanded="args.isExpanded"
+            @changeIsHoverSidebar="args.isHoverSidebar = $event"
+            @changeExpanded="args.isExpanded = $event"
+          >
+            <template #banner>
+              <AccountSetupProgress :value="args.progress" info-label="Add your bank account" />
+              <SidebarFeatureBanners
+                title="Late invoice fee"
+                is-stacked
+                description="You can now automate late fees on unpaid invoices by setting a fixed amount or percentage of the total, applied after a custom grace period."
+              />
+            </template>
+            <template #before>
+              <OcAccountSetup :isExpanded="args.isExpanded || args.isHoverSidebar" :progress="args.progress"/>
+            </template>
+            <template #user>
+              <Dropdown v-model="rightMenuDropdown" placement="bottom-end" :distance="10">
+                <Avatar class="uppercase cursor-pointer" :size="32">
+                  J
+                </Avatar>
+                <template #menu>
+                  <div class="flex flex-col">
+                    <div class="p-2 border-b border-gray-200">
+                      <a href="#">
+                        <DropdownItem text="userName" />
+                      </a>
+                      <a href="#">
+                        <DropdownItem text="Security" />
+                      </a>
+                    </div>
+                    <div class="p-2">
+                      <DropdownItem @click="logout" text="Logout" variant="destructive" />
+                    </div>
                   </div>
-                  <div class="p-2">
-                    <DropdownItem @click="logout" text="Logout" variant="destructive" />
-                  </div>
-                </div>
-              </template>
-            </Dropdown>
-          </template>
-        </Sidebar>
+                </template>
+              </Dropdown>
+            </template>
+          </Sidebar>
+          <div class="w-[calc(100%-300px)]">Content test 1</div>
+        </div>
       </Theme>
     `
   })
@@ -101,6 +109,7 @@ export const Default = {
 export const AllSidebar = {
   args: {
     isExpanded: true,
+    isHoverSidebar: false,
     payment_sidebar_menu: PAYMENTS_SIDEBAR_GROUP,
     pos_sidebar_menu: POS_SIDEBAR_GROUP,
     online_store_sidebar_menu: ONLINE_STORE_SIDEBAR_GROUP,
@@ -118,11 +127,12 @@ export const AllSidebar = {
           :sidebar-menu="args.payment_sidebar_menu"
           :isExpanded="args.isExpanded"
           @changeExpanded="args.isExpanded = $event"
+          @changeIsHoverSidebar="args.isHoverSidebar = $event"
         >
           <template #before>
-            <OcAccountSetup :isExpanded="args.isExpanded" :progress="args.progress"/>
+            <OcAccountSetup :isExpanded="args.isExpanded || args.isHoverSidebar" :progress="args.progress"/>
             <OcAccountSetup
-              :isExpanded="args.isExpanded"
+              :isExpanded="args.isExpanded || args.isHoverSidebar"
               :progress="args.progress"
               is-pending
               :payout-status="{ label: 'Pending', variant: 'warning'}"

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -79,6 +79,7 @@ const onClickOutside = (event) => {
     v-click-outside="onClickOutside"
     class="rounded-tl-lg rounded-bl-lg cursor-pointer flex flex-col transition-all duration-300 ease-in-out relative bg-[var(--oc-sidebar-background)]"
     :class="[allClassName, { 'overflow-auto': isExpanded }]"
+    style="zoom: 0.8661111"
   >
     <OcSidebarContent
       v-if="isExpanded"

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -103,7 +103,7 @@ watch(
       v-if="sidebarMenu[0]?.label"
       class="flex items-center text-md px-6 py-4 border-b border-gray-100 mx-auto w-full"
     >
-      <span v-if="isExpanded">{{ sidebarMenu[0]?.label }}</span>
+      <span v-if="isExpanded" class="font-medium">{{ sidebarMenu[0]?.label }}</span>
       <div
         class="border p-2 rounded-md"
         :class="{

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -53,16 +53,11 @@ const allClassName = computed(() => {
   return classNames + props.class
 })
 
-const timeOut = ref(null)
-
 const onMouseOverSidebar = () => {
-  clearTimeout(timeOut.value)
-  timeOut.value = setTimeout(() => {
-    if (!props.isExpanded) {
-      hoverSidebar.value = true
-      emit('changeIsHoverSidebar', true)
-    }
-  }, 100)
+  if (!props.isExpanded) {
+    hoverSidebar.value = true
+    emit('changeIsHoverSidebar', true)
+  }
 }
 
 const onChangeExpanded = (value, isHoverSidebar = false) => {

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { reactive, onMounted, computed, watch } from 'vue'
-import { SidebarHead, SideBarMenu, SidebarSubMenuItem, SidebarFooter } from '@/orchidui-core'
+import { SidebarHead, SideBarMenu, SidebarSubMenuItem, SidebarFooter, Icon } from '@/orchidui-core'
 
 const emit = defineEmits({
   /** Sidebar expanded/collapsed. Payload: new boolean state. */
@@ -96,9 +96,25 @@ watch(
 
 <template>
   <div
-    class="cursor-pointer flex flex-col transition-all duration-300 ease-in-out relative bg-[var(--oc-sidebar-background)]"
+    class="rounded-tl-lg rounded-bl-lg cursor-pointer flex flex-col transition-all duration-300 ease-in-out relative bg-[var(--oc-sidebar-background)]"
     :class="[allClassName, { 'overflow-auto': isExpanded }]"
   >
+    <div
+      v-if="sidebarMenu[0]?.label"
+      class="flex items-center text-md px-6 py-4 border-b border-gray-100 mx-auto w-full"
+    >
+      <span v-if="isExpanded">{{ sidebarMenu[0]?.label }}</span>
+      <div
+        class="border p-2 rounded-md"
+        :class="{
+          'ml-auto': isExpanded,
+          'mx-auto': !isExpanded
+        }"
+        @click="emit('changeExpanded', !isExpanded)"
+      >
+        <Icon name="plus" width="20" height="20" class="text-oc-primary-500" />
+      </div>
+    </div>
     <div class="flex flex-col flex-1 py-4 gap-5 px-6 animated-section">
       <slot name="before" :is-expanded="isExpanded" />
 
@@ -106,7 +122,7 @@ watch(
         <div v-if="!isExpanded" class="border-t border-oc-gray-200 last:hidden first:hidden"></div>
         <SidebarHead
           v-if="sidebar.label || sidebar.items.length > 0"
-          :label="sidebar.label"
+          :label="index > 0 ? sidebar.label : ''"
           :is-sidebar-expanded="isExpanded"
         >
           <SideBarMenu

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -1,10 +1,12 @@
 <script setup>
-import { reactive, onMounted, computed, watch } from 'vue'
-import { SidebarHead, SideBarMenu, SidebarSubMenuItem, SidebarFooter, Icon } from '@/orchidui-core'
+import { computed, ref } from 'vue'
+import OcSidebarContent from './OcSidebarContent.vue'
+import { clickOutside as vClickOutside } from '../../directives/clickOutside.js'
 
 const emit = defineEmits({
   /** Sidebar expanded/collapsed. Payload: new boolean state. */
   changeExpanded: null,
+  changeIsHoverSidebar: null,
   /** Sidebar icon was clicked. */
   'click:sidebar-icon': null,
   /** Expanded menu list changed. Payload: array of currently expanded menu `name` values. */
@@ -40,135 +42,102 @@ const props = defineProps({
   }
 })
 
-const state = reactive({
-  loading: true,
-  expanded: []
+const hoverSidebar = ref(false)
+
+const isHoverSidebar = computed(() => {
+  return hoverSidebar.value && !props.isExpanded
 })
-
-const expandMenu = (id) => {
-  if (!state.expanded.includes(id)) {
-    state.expanded.push(id)
-  } else {
-    state.expanded = state.expanded.filter((menuId) => menuId !== id)
-  }
-
-  emit('changeExpandedMenus', state.expanded)
-}
-
-const expandOrRedirect = (menuItem) => {
-  if (menuItem.children?.length) {
-    expandMenu(menuItem.name)
-  } else {
-    emit('redirect', menuItem)
-  }
-}
 
 const allClassName = computed(() => {
   let classNames = props.isExpanded ? 'w-[300px] ' : 'w-[76px] '
   return classNames + props.class
 })
 
-onMounted(() => {
-  props.sidebarMenu.forEach((sideMenu) => {
-    sideMenu.items.forEach((menu) => {
-      // check if menu active
-      if (menu.children) {
-        menu.children.forEach((submenu) => {
-          if (submenu.active) {
-            expandMenu(menu.name)
-          }
-        })
-      }
-    })
-  })
-  state.loading = false
-})
+const timeOut = ref(null)
 
-watch(
-  () => props.isExpanded,
-  (value) => {
-    if (!value) {
-      state.expanded = []
+const onMouseOverSidebar = () => {
+  clearTimeout(timeOut.value)
+  timeOut.value = setTimeout(() => {
+    if (!props.isExpanded) {
+      hoverSidebar.value = true
+      emit('changeIsHoverSidebar', true)
     }
+  }, 100)
+}
+
+const onChangeExpanded = (value, isHoverSidebar = false) => {
+  emit('changeExpanded', isHoverSidebar ? true : value)
+  if (!value) {
+    hoverSidebar.value = false
+    emit('changeIsHoverSidebar', false)
   }
-)
+}
+const onClickOutside = (event) => {
+  console.log('onClickOutside', event)
+  hoverSidebar.value = false
+  emit('changeIsHoverSidebar', false)
+}
 </script>
 
 <template>
   <div
+    v-click-outside="onClickOutside"
     class="rounded-tl-lg rounded-bl-lg cursor-pointer flex flex-col transition-all duration-300 ease-in-out relative bg-[var(--oc-sidebar-background)]"
     :class="[allClassName, { 'overflow-auto': isExpanded }]"
   >
-    <div
-      v-if="sidebarMenu[0]?.label"
-      class="flex items-center text-md px-6 py-4 border-b border-gray-100 mx-auto w-full"
+    <OcSidebarContent
+      v-if="isExpanded"
+      :sidebar-menu="sidebarMenu"
+      :display-name="displayName"
+      :is-expanded="isExpanded"
+      :is-sidebar-raw-expanded="isExpanded"
+      @change-expanded="onChangeExpanded"
+      @change-expanded-menus="emit('changeExpandedMenus', $event)"
+      @redirect="emit('redirect', $event)"
+      @user-click="emit('user-click')"
+      @support-click="emit('support-click')"
     >
-      <span v-if="isExpanded" class="font-medium">{{ sidebarMenu[0]?.label }}</span>
+      <template #before>
+        <slot name="before" :is-expanded="isExpanded" />
+      </template>
+      <template #after>
+        <slot name="after" :is-expanded="isExpanded" />
+      </template>
+      <template #banner>
+        <slot name="banner" />
+      </template>
+    </OcSidebarContent>
+    <div v-else class="h-full w-full min-h-[100vh] relative">
       <div
-        class="border p-2 rounded-md"
+        class="position absolute transition-all duration-300 ease-in-out bg-[var(--oc-sidebar-background)]"
         :class="{
-          'ml-auto': isExpanded,
-          'mx-auto': !isExpanded
+          'w-[300px] min-h-[100vh]': isHoverSidebar,
+          'w-[76px]': !isHoverSidebar
         }"
-        @click="emit('changeExpanded', !isExpanded)"
+        @mouseover="onMouseOverSidebar"
       >
-        <Icon name="plus" width="20" height="20" class="text-oc-primary-500" />
+        <OcSidebarContent
+          :sidebar-menu="sidebarMenu"
+          :display-name="displayName"
+          :is-expanded="isHoverSidebar"
+          :is-sidebar-raw-expanded="isHoverSidebar"
+          @change-expanded="onChangeExpanded($event, true)"
+          @change-expanded-menus="emit('changeExpandedMenus', $event)"
+          @redirect="emit('redirect', $event)"
+          @user-click="emit('user-click')"
+          @support-click="emit('support-click')"
+        >
+          <template #before>
+            <slot name="before" :is-expanded="isHoverSidebar" />
+          </template>
+          <template #after>
+            <slot name="after" :is-expanded="isHoverSidebar" />
+          </template>
+          <template #banner>
+            <slot name="banner" />
+          </template>
+        </OcSidebarContent>
       </div>
     </div>
-    <div class="flex flex-col flex-1 py-4 gap-5 px-6 animated-section">
-      <slot name="before" :is-expanded="isExpanded" />
-
-      <template v-for="(sidebar, index) in sidebarMenu" :key="index">
-        <div v-if="!isExpanded" class="border-t border-oc-gray-200 last:hidden first:hidden"></div>
-        <SidebarHead
-          v-if="sidebar.label || sidebar.items.length > 0"
-          :label="index > 0 ? sidebar.label : ''"
-          :is-sidebar-expanded="isExpanded"
-        >
-          <SideBarMenu
-            v-for="(menu, menuIndex) in sidebar.items"
-            :key="menuIndex"
-            :icon="menu.icon"
-            :label="menu.label"
-            :is-children="!!menu.children"
-            :is-active="
-              menu.active || (menu.children && menu.children?.some((child) => child.active))
-            "
-            :is-expanded="isExpanded"
-            :is-new="menu.isNew"
-            :is-try-it="menu.isTryIt"
-            :is-beta="menu.isBeta"
-            :is-show-badge="menu.badgeVisible ? menu.badgeVisible(menu) : true"
-            :is-menu-expanded="state.expanded.includes(menu.name)"
-            @click="expandOrRedirect(menu)"
-            @close-menu="expandMenu(menu.name)"
-          >
-            <SidebarSubMenuItem
-              v-for="(submenu, submenuIndex) in menu.children"
-              :key="submenuIndex"
-              :icon="submenu.icon"
-              :label="submenu.label"
-              :is-active="submenu.active"
-              :is-new="submenu.isNew"
-              :is-beta="submenu.isBeta"
-              :is-try-it="submenu.isTryIt"
-              :is-expanded="isExpanded"
-              :is-show-badge="submenu.badgeVisible ? submenu.badgeVisible(submenu) : true"
-              @click="$emit('redirect', submenu)"
-            />
-          </SideBarMenu>
-        </SidebarHead>
-      </template>
-
-      <slot name="after" :is-expanded="isExpanded" />
-    </div>
-    <SidebarFooter
-      :is-expanded="isExpanded"
-      :display-name="displayName"
-      @user-click="$emit('user-click')"
-      @support-click="$emit('support-click')"
-    >
-      <slot name="banner" />
-    </SidebarFooter>
   </div>
 </template>

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -49,7 +49,7 @@ const isHoverSidebar = computed(() => {
 })
 
 const allClassName = computed(() => {
-  let classNames = props.isExpanded ? 'w-[254px] ' : 'w-[56px] '
+  let classNames = props.isExpanded ? 'w-[250px] ' : 'w-[56px] '
   return classNames + props.class
 })
 
@@ -79,7 +79,7 @@ const onClickOutside = (event) => {
     v-click-outside="onClickOutside"
     class="rounded-tl-lg rounded-bl-lg cursor-pointer flex flex-col transition-all duration-300 ease-in-out relative bg-[var(--oc-sidebar-background)]"
     :class="[allClassName, { 'overflow-auto': isExpanded }]"
-    style="zoom: 0.8661111"
+    style="zoom: 0.88"
   >
     <OcSidebarContent
       v-if="isExpanded"
@@ -107,7 +107,7 @@ const onClickOutside = (event) => {
       <div
         class="position absolute transition-all duration-300 ease-in-out bg-[var(--oc-sidebar-background)]"
         :class="{
-          'w-[254px] min-h-[100vh]': isHoverSidebar,
+          'w-[250px] min-h-[100vh]': isHoverSidebar,
           'w-[56px]': !isHoverSidebar
         }"
         @mouseover="onMouseOverSidebar"

--- a/packages/core/src/Elements/Sidebar/OcSidebar.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebar.vue
@@ -49,7 +49,7 @@ const isHoverSidebar = computed(() => {
 })
 
 const allClassName = computed(() => {
-  let classNames = props.isExpanded ? 'w-[300px] ' : 'w-[76px] '
+  let classNames = props.isExpanded ? 'w-[254px] ' : 'w-[56px] '
   return classNames + props.class
 })
 
@@ -106,8 +106,8 @@ const onClickOutside = (event) => {
       <div
         class="position absolute transition-all duration-300 ease-in-out bg-[var(--oc-sidebar-background)]"
         :class="{
-          'w-[300px] min-h-[100vh]': isHoverSidebar,
-          'w-[76px]': !isHoverSidebar
+          'w-[254px] min-h-[100vh]': isHoverSidebar,
+          'w-[56px]': !isHoverSidebar
         }"
         @mouseover="onMouseOverSidebar"
       >

--- a/packages/core/src/Elements/Sidebar/OcSidebarContent.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebarContent.vue
@@ -77,7 +77,7 @@ watch(
 <template>
   <div
     v-if="sidebarMenu[0]?.label"
-    class="flex items-center text-md px-6 py-4 border-b border-gray-100 mx-auto w-full"
+    class="flex items-center text-md px-4 py-4 border-b border-gray-100 mx-auto w-full"
   >
     <span v-if="isExpanded" class="font-medium">{{ sidebarMenu[0]?.label }}</span>
     <div
@@ -91,7 +91,7 @@ watch(
       <Icon name="plus" width="20" height="20" class="text-oc-primary-500" />
     </div>
   </div>
-  <div class="flex flex-col flex-1 py-4 gap-5 px-6 animated-section">
+  <div class="flex flex-col flex-1 py-4 gap-5 px-4 animated-section">
     <slot name="before" :is-expanded="isExpanded" />
     <template v-for="(sidebar, index) in sidebarMenu" :key="index">
       <div v-if="!isExpanded" class="border-t border-oc-gray-200 last:hidden first:hidden"></div>

--- a/packages/core/src/Elements/Sidebar/OcSidebarContent.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebarContent.vue
@@ -1,0 +1,148 @@
+<script setup>
+import { reactive, onMounted, watch } from 'vue'
+import { SidebarHead, SideBarMenu, SidebarSubMenuItem, SidebarFooter, Icon } from '@/orchidui-core'
+
+const emit = defineEmits({
+  changeExpanded: null,
+  changeExpandedMenus: null,
+  redirect: null,
+  'user-click': null,
+  'support-click': null
+})
+
+const props = defineProps({
+  sidebarMenu: {
+    type: Array
+  },
+  displayName: {
+    type: String
+  },
+  /** Computed value: true when sidebar is expanded or hovered. Used for rendering. */
+  isExpanded: {
+    type: Boolean,
+    default: true
+  },
+  /** Raw isExpanded prop from parent — watched to reset expanded menus on collapse. */
+  isSidebarRawExpanded: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const state = reactive({
+  expanded: []
+})
+
+const expandMenu = (id) => {
+  if (!state.expanded.includes(id)) {
+    state.expanded.push(id)
+  } else {
+    state.expanded = state.expanded.filter((menuId) => menuId !== id)
+  }
+  emit('changeExpandedMenus', state.expanded)
+}
+
+const expandOrRedirect = (menuItem) => {
+  if (menuItem.children?.length) {
+    expandMenu(menuItem.name)
+  } else {
+    emit('redirect', menuItem)
+  }
+}
+
+onMounted(() => {
+  props.sidebarMenu.forEach((sideMenu) => {
+    sideMenu.items.forEach((menu) => {
+      if (menu.children) {
+        menu.children.forEach((submenu) => {
+          if (submenu.active) {
+            expandMenu(menu.name)
+          }
+        })
+      }
+    })
+  })
+})
+
+watch(
+  () => props.isSidebarRawExpanded,
+  (value) => {
+    if (!value) {
+      state.expanded = []
+    }
+  }
+)
+</script>
+
+<template>
+  <div
+    v-if="sidebarMenu[0]?.label"
+    class="flex items-center text-md px-6 py-4 border-b border-gray-100 mx-auto w-full"
+  >
+    <span v-if="isExpanded" class="font-medium">{{ sidebarMenu[0]?.label }}</span>
+    <div
+      class="border p-2 rounded-md"
+      :class="{
+        'ml-auto': isExpanded,
+        'mx-auto': !isExpanded
+      }"
+      @click="emit('changeExpanded', !isExpanded)"
+    >
+      <Icon name="plus" width="20" height="20" class="text-oc-primary-500" />
+    </div>
+  </div>
+  <div class="flex flex-col flex-1 py-4 gap-5 px-6 animated-section">
+    <slot name="before" :is-expanded="isExpanded" />
+    <template v-for="(sidebar, index) in sidebarMenu" :key="index">
+      <div v-if="!isExpanded" class="border-t border-oc-gray-200 last:hidden first:hidden"></div>
+      <SidebarHead
+        v-if="sidebar.label || sidebar.items.length > 0"
+        :label="index > 0 ? sidebar.label : ''"
+        :is-sidebar-expanded="isExpanded"
+      >
+        <SideBarMenu
+          v-for="(menu, menuIndex) in sidebar.items"
+          :key="menuIndex"
+          :icon="menu.icon"
+          :label="menu.label"
+          :is-children="!!menu.children"
+          :is-active="
+            menu.active || (menu.children && menu.children?.some((child) => child.active))
+          "
+          :is-expanded="isExpanded"
+          :is-new="menu.isNew"
+          :is-try-it="menu.isTryIt"
+          :is-beta="menu.isBeta"
+          :is-show-badge="menu.badgeVisible ? menu.badgeVisible(menu) : true"
+          :is-menu-expanded="state.expanded.includes(menu.name)"
+          @click="expandOrRedirect(menu)"
+          @close-menu="expandMenu(menu.name)"
+        >
+          <SidebarSubMenuItem
+            v-for="(submenu, submenuIndex) in menu.children"
+            :key="submenuIndex"
+            :icon="submenu.icon"
+            :label="submenu.label"
+            :is-active="submenu.active"
+            :is-new="submenu.isNew"
+            :is-beta="submenu.isBeta"
+            :is-try-it="submenu.isTryIt"
+            :is-expanded="isExpanded"
+            :is-show-badge="submenu.badgeVisible ? submenu.badgeVisible(submenu) : true"
+            @click="emit('redirect', submenu)"
+          />
+        </SideBarMenu>
+      </SidebarHead>
+    </template>
+
+    <slot name="after" :is-expanded="isExpanded" />
+  </div>
+  <SidebarFooter
+    :is-expanded="isExpanded"
+    :display-name="displayName"
+    @user-click="emit('user-click')"
+    @support-click="emit('support-click')"
+  >
+    <slot name="banner" />
+  </SidebarFooter>
+</template>

--- a/packages/core/src/Elements/Sidebar/OcSidebarMenu.vue
+++ b/packages/core/src/Elements/Sidebar/OcSidebarMenu.vue
@@ -54,13 +54,13 @@
         </template>
         <Icon
           v-if="isExpanded && isChildren"
-          name="triangle-down"
-          width="10"
-          height="10"
-          class="text-oc-accent-1-500"
+          name="chevron-right"
+          width="20"
+          height="20"
+          class="text-[var(--oc-sidebar-menu-active-icon)]"
           :class="{
-            'rotate-0 opacity-25': isMenuExpanded,
-            '-rotate-90 opacity-15': !isMenuExpanded
+            'rotate-0 opacity-25': !isMenuExpanded,
+            '-rotate-90 opacity-15': isMenuExpanded
           }"
         />
       </div>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.96.0",
+    "@orchidui/core": "1.97.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -50,7 +50,7 @@
   --oc-accent-2-300: #d8a4f6;
   --oc-accent-2-400: #c880f2;
   --oc-accent-2-500: #b14aed;
-  --oc-accent-2-600: #7D1AB7;
+  --oc-accent-2-600: #7d1ab7;
 
   --oc-accent-3-50-tr: #ff6b6c1a;
   --oc-accent-3-50: #fff0f0;
@@ -69,7 +69,7 @@
   --oc-success-300: #89dbb5;
   --oc-success-400: #59cc97;
   --oc-success-500: #2bc37d;
-  --oc-success-600: #238B5B;
+  --oc-success-600: #238b5b;
 
   --oc-warning-50-tr: #f4b8401a;
   --oc-warning-50: #fff9ec;
@@ -79,7 +79,7 @@
   --oc-warning-400: #ffd47d;
   --oc-warning-500: #f4b840;
   --oc-warning-600: #eaa00c;
-  --oc-warning-700: #BD8400;
+  --oc-warning-700: #bd8400;
 
   --oc-error-50-tr: #c420211a;
   --oc-error-50: #f9e9e9;
@@ -88,7 +88,7 @@
   --oc-error-300: #dc797a;
   --oc-error-400: #d04d4d;
   --oc-error-500: #dc3545;
-  --oc-error-600: #C20A1C;
+  --oc-error-600: #c20a1c;
 
   --oc-red-50-tr: rgba(255, 107, 108, 0.1);
   --oc-red-50: rgba(255, 240, 240, 1);
@@ -99,8 +99,8 @@
   --oc-red-500: rgba(255, 137, 137, 1);
   --oc-red-600: rgba(255, 51, 52, 1);
 
-  --oc-tosca-200: #EDFBFD;
-  --oc-tosca-500: #0495A9;
+  --oc-tosca-200: #edfbfd;
+  --oc-tosca-500: #0495a9;
 
   --button-primary-default: linear-gradient(180deg, #4179e2 0%, #1f5bcc 100%);
   --button-primary-hover: linear-gradient(180deg, #4179e2 0%, #2f6ddf 100%);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the sidebar to match Linear HIT-18069 (Sidebar Navigation v3): hover-to-expand with click-outside closing, a header label with a plus to expand/collapse, and clearer submenu toggles. Extracts `OcSidebarContent` and refines widths, zoom, spacing, and font sizes.

- **New Features**
  - Collapsed sidebar expands on hover and closes on click outside; emits `changeIsHoverSidebar`.
  - Header shows the first section label with a plus-button; hides the first group label to avoid duplication.
  - Submenu toggle uses a rotating chevron-right; color from `--oc-sidebar-menu-active-icon`.
  - Extracted `OcSidebarContent` for rendering and expanded-menu state (exported via `OcSidebar.js`); set widths to 250px/56px, added rounded left edges, applied `zoom: 0.88`, and adjusted pending alert spacing and font sizes.
  - Sample menu: removed default `active` flags and normalized group labels to Title Case.

- **Dependencies**
  - Bump `@orchidui/core` and `@orchidui/dashboard` to `1.97.0`; dashboard now depends on `@orchidui/core@1.97.0`.

<sup>Written for commit 9d62ad5052f959ae641b9e9ce7413f55bc37de0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

