### PR TITLE
Table: support disabled row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.95.0",
+        "@orchidui/core": "1.96.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.95.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.95.0.tgz",
-      "integrity": "sha512-+ZuUrpKCkA2ABCXUOd/8gaizVPEtEXMZU4d9PifHcEqHAFS0GH6Hu/0c+X+9gSx3jyrNYuWA67RjzOlBRirNrQ==",
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.96.0.tgz",
+      "integrity": "sha512-+FUHHtz10g1zM2AFv0qAR1hk4ZXGt4p8wqSU5MqNmP9EiQUFPw+DeEgJwJmDGGp5RswTN3F4ubJQ9WaXlaWp3g==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataDisplay/NewTable/OcNewTable.stories.js
+++ b/packages/core/src/DataDisplay/NewTable/OcNewTable.stories.js
@@ -210,3 +210,100 @@ export const Default = {
     `
   })
 }
+
+export const DisabledRows = {
+  description:
+    'Selectable table where specific rows are disabled via the `disabledRows` prop. Disabled rows hide their checkbox and are excluded from the select-all action.',
+  highlights: [
+    'disabledRows — array of row objects matched by rowKey',
+    'isSelectable: true — show row checkboxes',
+    'disabled rows hide their checkbox',
+    'select-all only toggles selectable (non-disabled) rows'
+  ],
+  args: {
+    isLoading: false,
+    options: {
+      headers: [
+        {
+          key: 'email',
+          label: 'Email',
+          variant: 'tooltip',
+          width: 300,
+          tooltip: true
+        },
+        {
+          key: 'id',
+          label: 'ID',
+          isCopy: true,
+          class: 'text-oc-text-400'
+        },
+        {
+          key: 'amount',
+          label: 'Amount',
+          class: 'font-reddit-mono font-semibold'
+        },
+        {
+          key: 'status',
+          label: 'Status'
+        }
+      ],
+      fields: [
+        {
+          id: '#TXN-001',
+          email: 'john.doe@example.com',
+          amount: '2,234.56',
+          currency: 'SGD',
+          status: 'success'
+        },
+        {
+          id: '#TXN-002',
+          email: 'jane.smith@example.com',
+          amount: '1,050.00',
+          currency: 'SGD',
+          status: 'neutral'
+        },
+        {
+          id: '#TXN-003',
+          email: 'alex.lee@example.com',
+          amount: '780.00',
+          currency: 'SGD',
+          status: 'success'
+        },
+        {
+          id: '#TXN-004',
+          email: 'mia.wong@example.com',
+          amount: '410.25',
+          currency: 'SGD',
+          status: 'neutral'
+        }
+      ],
+      isSelectable: true
+    }
+  },
+  render: (args) => ({
+    components: { Theme, NewTable, Chip },
+    setup() {
+      const selectedRows = ref([])
+      // Disable the 2nd and 4th rows — matched against fields by `rowKey` (default 'id').
+      const disabledRows = [args.options.fields[1], args.options.fields[3]]
+      return { options: args.options, selectedRows, disabledRows, args }
+    },
+    template: `
+      <Theme>
+        <NewTable
+          v-model:selected="selectedRows"
+          :options="options"
+          :disabled-rows="disabledRows"
+          :is-loading="args.isLoading"
+        >
+          <template #amount="{ item }">
+            {{ item.currency }} {{ item.amount }}
+          </template>
+          <template #status="{ item }">
+            <Chip :variant="item.status" label="Some label" class="truncate" />
+          </template>
+        </NewTable>
+      </Theme>
+    `
+  })
+}

--- a/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
+++ b/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
@@ -29,7 +29,7 @@
                 <div class="flex p-3 items-center min-h-[35px] border-b border-oc-text-200">
                   <Checkbox
                     class="items-center"
-                    :model-value="selectableRows.length > 0 && selectedRows.length === selectableRows.length"
+                    :model-value="areAllSelectableSelected"
                     @update:model-value="selectAllRows"
                   />
                 </div>
@@ -228,6 +228,15 @@ const isRowDisabled = (row) =>
   props.disabledRows.some((r) => (typeof r === 'string' ? r : getRowKey.value(r)) === getRowKey.value(row))
 
 const selectableRows = computed(() => fields.value.filter((row) => !isRowDisabled(row)))
+
+// True only when every selectable row is actually selected. Checking membership
+// (not array lengths) keeps this correct even when `selected` includes disabled
+// rows, which would otherwise make a raw length comparison report a false "all".
+const areAllSelectableSelected = computed(() => {
+  if (!selectableRows.value.length) return false
+  const selectedKeys = new Set(selectedRows.value.map((r) => getRowKey.value(r)))
+  return selectableRows.value.every((row) => selectedKeys.has(getRowKey.value(row)))
+})
 
 const COLUMN_WIDTH = {
   DEFAULT: 125,
@@ -654,10 +663,16 @@ const selectRow = (row) => {
 }
 
 const selectAllRows = () => {
-  const allRowsSelected =
-    selectableRows.value.length > 0 && selectedRows.value.length === selectableRows.value.length
-
-  selectedRows.value = allRowsSelected ? [] : [...selectableRows.value]
+  if (areAllSelectableSelected.value) {
+    // Deselect selectable rows, preserving any other entries (e.g. pre-selected disabled rows).
+    const selectableKeys = new Set(selectableRows.value.map((r) => getRowKey.value(r)))
+    selectedRows.value = selectedRows.value.filter((r) => !selectableKeys.has(getRowKey.value(r)))
+  } else {
+    // Add every selectable row not already selected, keeping existing selections.
+    const selectedKeys = new Set(selectedRows.value.map((r) => getRowKey.value(r)))
+    const toAdd = selectableRows.value.filter((r) => !selectedKeys.has(getRowKey.value(r)))
+    selectedRows.value = [...selectedRows.value, ...toAdd]
+  }
 }
 
 const onClickRow = (field, header) => {

--- a/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
+++ b/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
@@ -29,7 +29,7 @@
                 <div class="flex p-3 items-center min-h-[35px] border-b border-oc-text-200">
                   <Checkbox
                     class="items-center"
-                    :model-value="selectedRows.length === fields.length"
+                    :model-value="selectableRows.length > 0 && selectedRows.length === selectableRows.length"
                     @update:model-value="selectAllRows"
                   />
                 </div>
@@ -103,6 +103,7 @@
               :select-row="selectRow"
               :get-row-key="getRowKey"
               :get-sticky-classes="getStickyClasses"
+              :is-row-disabled="isRowDisabled"
               @toggle-children="recreateResizeHandles"
               @click:col="onClickRow"
             >
@@ -185,6 +186,15 @@ const props = defineProps({
   isLoading: {
     type: Boolean,
     default: false
+  },
+  /**
+   * Rows that cannot be selected. Array of row data objects, matched against
+   * each row by `rowKey`. Their selection checkbox is hidden and they are
+   * excluded from the select-all action.
+   */
+  disabledRows: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -213,6 +223,11 @@ const selectedRows = computed({
 })
 
 const sortedFields = computed(() => fields.value)
+
+const isRowDisabled = (row) =>
+  props.disabledRows.some((r) => (typeof r === 'string' ? r : getRowKey.value(r)) === getRowKey.value(row))
+
+const selectableRows = computed(() => fields.value.filter((row) => !isRowDisabled(row)))
 
 const COLUMN_WIDTH = {
   DEFAULT: 125,
@@ -639,9 +654,10 @@ const selectRow = (row) => {
 }
 
 const selectAllRows = () => {
-  const allRowsSelected = selectedRows.value.length === fields.value.length
+  const allRowsSelected =
+    selectableRows.value.length > 0 && selectedRows.value.length === selectableRows.value.length
 
-  selectedRows.value = allRowsSelected ? [] : [...fields.value]
+  selectedRows.value = allRowsSelected ? [] : [...selectableRows.value]
 }
 
 const onClickRow = (field, header) => {

--- a/packages/core/src/DataDisplay/NewTable/OcTableRow.vue
+++ b/packages/core/src/DataDisplay/NewTable/OcTableRow.vue
@@ -31,6 +31,7 @@
     >
       <div class="flex p-3 items-center min-h-[35px]">
         <Checkbox
+          v-if="!isRowDisabled(row)"
           class="items-center"
           :model-value="selectedRows.some((r) => getRowKey(r) === getRowKey(row))"
           @update:model-value="selectRow(row)"
@@ -93,6 +94,7 @@
       :get-row-key="getRowKey"
       :select-row="selectRow"
       :get-sticky-classes="getStickyClasses"
+      :is-row-disabled="isRowDisabled"
     >
       <template v-for="(_, name) in $slots" #[name]="slotProps">
         <slot :name="name" v-bind="{ ...slotProps, isChild: true }" />
@@ -162,6 +164,11 @@ const props = defineProps({
   getStickyClasses: {
     type: Function,
     default: () => ''
+  },
+  /** Function `(row) => boolean` — when it returns true, the row's selection checkbox is hidden. */
+  isRowDisabled: {
+    type: Function,
+    default: () => false
   },
   /** Whether this row is rendered as a child of an expandable parent row. */
   isChild: {

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -97,6 +97,15 @@ const props = defineProps({
   selectedIndex: {
     type: Number,
     default: -1
+  },
+  /**
+   * Rows that cannot be selected (NewTable only). Array of row data objects,
+   * matched against each row by `rowKey`. Their selection checkbox is hidden
+   * and they are excluded from the select-all action.
+   */
+  disabledRows: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -403,6 +412,7 @@ onMounted(() => {
       :row-class="rowClass"
       :row-link="rowLink"
       :selected-index="selectedIndex"
+      :disabled-rows="disabledRows"
       :is-sticky="tableOptions.isSticky"
       :is-borderless="tableOptions.isBorderless"
       @update:selected="$emit('update:selected', $event)"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.96.0",
+    "@orchidui/core": "1.97.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add disabled row support to the new table and fix select-all so the header checkbox reflects only selectable rows. Exposed via `OcDataTable`, adds a DisabledRows story, and bumps `@orchidui/core` and `@orchidui/dashboard` to 1.99.0, aligned with HIT-18107.

- **New Features**
  - `disabledRows` prop in `NewTable`; rows matched by `rowKey` are not selectable and their checkbox is hidden (applies to child rows).
  - `OcDataTable` forwards `disabledRows`; added “DisabledRows” story.

- **Bug Fixes**
  - Header select-all shows checked only when all selectable rows are selected.
  - Select-all toggles only selectable rows and preserves any pre-selected disabled rows.

<sup>Written for commit 6b238be3e6fc481461727eabba4443c95616cacf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

