### PR TITLE
fix render icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.96.0",
+      "version": "1.98.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.96.0",
+      "version": "1.98.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.95.0",
+        "@orchidui/core": "1.97.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.95.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.95.0.tgz",
-      "integrity": "sha512-+ZuUrpKCkA2ABCXUOd/8gaizVPEtEXMZU4d9PifHcEqHAFS0GH6Hu/0c+X+9gSx3jyrNYuWA67RjzOlBRirNrQ==",
+      "version": "1.97.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.97.0.tgz",
+      "integrity": "sha512-faRtGdrzMWtkpgRyExJ76YnI/cMKy81MS+PoW8snMA8iTaJSGzTcCgA4QEbhs2vydX8Zz61cdSXyWdfujGd9yA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.98.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.97.0",
+        "@orchidui/core": "1.98.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.97.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.97.0.tgz",
-      "integrity": "sha512-faRtGdrzMWtkpgRyExJ76YnI/cMKy81MS+PoW8snMA8iTaJSGzTcCgA4QEbhs2vydX8Zz61cdSXyWdfujGd9yA==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.98.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,8 +14,8 @@
     "libphonenumber-js": "^1.10.51",
     "lodash-es": "^4.17.21",
     "v-calendar": "^3.1.2",
-    "vue-draggable-next": "^2.2.1",
-    "vue-advanced-cropper": "^2.8.8"
+    "vue-advanced-cropper": "^2.8.8",
+    "vue-draggable-next": "^2.2.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
+++ b/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
@@ -30,9 +30,35 @@ const props = defineProps({
   height: {
     type: [String, Number],
     default: '24'
+  },
+  /** Fill value applied to the SVG root. Use "none" for stroke-based icons. */
+  fill: {
+    type: String,
+    default: 'currentColor'
   }
 })
 const iconRef = ref(null)
+const uid = Math.random().toString(36).slice(2, 8)
+
+// Scope all id="x" and url(#x) references with a per-instance prefix so that
+// icons sharing generic clip-path IDs (e.g. id="a") don't collide when multiple
+// icons are rendered in the same document.
+const scopeIds = (html) => {
+  const ids = new Set()
+  const idRe = /\bid="([^"]+)"/g
+  let m
+  while ((m = idRe.exec(html)) !== null) {
+    ids.add(m[1])
+  }
+  let result = html
+  for (const id of ids) {
+    const safe = `oc-${props.name}-${uid}-${id}`
+    result = result.replaceAll(`id="${id}"`, `id="${safe}"`)
+    result = result.replaceAll(`url(#${id})`, `url(#${safe})`)
+    result = result.replaceAll(`href="#${id}"`, `href="#${safe}"`)
+  }
+  return result
+}
 
 const setIconRef = (text, isNew = true) => {
   if (isNew) {
@@ -42,11 +68,9 @@ const setIconRef = (text, isNew = true) => {
       iconDom.querySelector('svg').removeAttribute('id')
       iconDom.querySelector('svg').removeAttribute('width')
       iconDom.querySelector('svg').removeAttribute('height')
+      // Always cache with currentColor; fill is applied at inject time so each
+      // instance can use a different fill without invalidating the shared cache.
       iconDom.querySelector('svg').setAttribute('fill', 'currentColor')
-
-      if (iconRef.value) {
-        iconRef.value.innerHTML = iconDom.innerHTML
-      }
 
       if (window.ORCHID_ICONS) {
         window.ORCHID_ICONS[props.name] = iconDom.innerHTML
@@ -55,10 +79,18 @@ const setIconRef = (text, isNew = true) => {
           [props.name]: iconDom.innerHTML
         }
       }
+
+      if (iconRef.value) {
+        iconRef.value.innerHTML = scopeIds(
+          iconDom.innerHTML.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${props.fill}"`)
+        )
+      }
     }
     iconDom.remove()
   } else if (iconRef.value) {
-    iconRef.value.innerHTML = text
+    iconRef.value.innerHTML = scopeIds(
+      text.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${props.fill}"`)
+    )
   }
 }
 

--- a/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
+++ b/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
@@ -9,7 +9,8 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, nextTick } from 'vue'
+import { ref, watch, onMounted, nextTick, onUnmounted } from 'vue'
+
 const props = defineProps({
   /** Base URL path where SVG icon files are served from. */
   path: {
@@ -37,8 +38,19 @@ const props = defineProps({
     default: 'currentColor'
   }
 })
+
 const iconRef = ref(null)
 const uid = Math.random().toString(36).slice(2, 8)
+let abortController = null
+
+// Only allow safe CSS color values to prevent attribute injection via fill prop.
+const sanitizeFill = (fill) => {
+  if (/^[a-zA-Z0-9#(),.\s%_-]+$/.test(fill)) return fill
+  return 'currentColor'
+}
+
+// Only allow icon names with safe filesystem characters to prevent path traversal.
+const sanitizeName = (name) => name.replace(/[^a-zA-Z0-9_/-]/g, '')
 
 // Scope all id="x" and url(#x) references with a per-instance prefix so that
 // icons sharing generic clip-path IDs (e.g. id="a") don't collide when multiple
@@ -61,6 +73,8 @@ const scopeIds = (html) => {
 }
 
 const setIconRef = (text, isNew = true) => {
+  const safeFill = sanitizeFill(props.fill)
+
   if (isNew) {
     const iconDom = document.createElement('div')
     iconDom.innerHTML = text
@@ -82,36 +96,43 @@ const setIconRef = (text, isNew = true) => {
 
       if (iconRef.value) {
         iconRef.value.innerHTML = scopeIds(
-          iconDom.innerHTML.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${props.fill}"`)
+          iconDom.innerHTML.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${safeFill}"`)
         )
       }
     }
     iconDom.remove()
   } else if (iconRef.value) {
     iconRef.value.innerHTML = scopeIds(
-      text.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${props.fill}"`)
+      text.replace(/(<svg\b[^>]*)\bfill="[^"]*"/, `$1fill="${safeFill}"`)
     )
   }
 }
 
 const renderIcon = () => {
-  if (window.oc_icons) {
-    window.oc_icons = null // clear old icons
+  const safeName = sanitizeName(props.name)
+  if (!safeName) return
+
+  if (window.ORCHID_ICONS && window.ORCHID_ICONS[safeName]) {
+    setIconRef(window.ORCHID_ICONS[safeName], false)
+    return
   }
-  if (window.ORCHID_ICONS && window.ORCHID_ICONS[props.name]) {
-    setIconRef(window.ORCHID_ICONS[props.name], false)
-  } else {
-    fetch(`${props.path}/${props.name}.svg`)
-      .then((r) => (r.status === 200 ? r.text() : ''))
-      .then((text) => {
-        if (text && iconRef.value) {
-          setIconRef(text, true)
-        }
-      })
-      .catch(() => {
-        console.error(`Icon ${props.name} not found`)
-      })
-  }
+
+  // Abort any in-flight fetch for a previous name to prevent stale renders.
+  if (abortController) abortController.abort()
+  abortController = new AbortController()
+
+  fetch(`${props.path}/${safeName}.svg`, { signal: abortController.signal })
+    .then((r) => (r.status === 200 ? r.text() : ''))
+    .then((text) => {
+      if (text && text.includes('<svg') && iconRef.value) {
+        setIconRef(text, true)
+      }
+    })
+    .catch((err) => {
+      if (err.name !== 'AbortError') {
+        console.error(`Icon ${safeName} not found`)
+      }
+    })
 }
 
 onMounted(async () => {
@@ -119,6 +140,10 @@ onMounted(async () => {
   if (iconRef.value) {
     renderIcon()
   }
+})
+
+onUnmounted(() => {
+  if (abortController) abortController.abort()
 })
 
 watch(

--- a/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
+++ b/packages/core/src/MediaAndIcons/Icon/OcIcon.vue
@@ -154,4 +154,13 @@ watch(
     }
   }
 )
+
+watch(
+  () => props.fill,
+  () => {
+    if (iconRef.value) {
+      renderIcon()
+    }
+  }
+)
 </script>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.96.0",
+  "version": "1.98.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.96.0",
+    "@orchidui/core": "1.98.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes SVG icon rendering conflicts and color application in OcIcon. Adds safety checks and abortable fetches to avoid stale or unsafe renders.

- **Bug Fixes**
  - Scoped internal SVG ids and refs (url(#...) and href(#...)) with a unique prefix to prevent collisions across icons.
  - Cache icon markup with currentColor and inject with the requested fill; strip id, width, and height from the SVG root; apply fill updates reactively.
  - Hardened fetching/rendering: sanitize fill and icon name, abort in-flight fetches on change/unmount, and inject only valid <svg>.

- **Dependencies**
  - Bumped `@orchidui/core` and `@orchidui/dashboard` to `1.98.0`.

<sup>Written for commit 4519712cf9685e01e0bf22d01815eeddd70259a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

