### PR TITLE
[HIT-18277] Allow Ctrl+V paste in number/phone inputs on Windows/Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.100.0",
+      "version": "1.101.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,33 +11181,16 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.100.0",
+      "version": "1.101.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.99.0",
+        "@orchidui/core": "1.101.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.99.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.99.0.tgz",
-      "integrity": "sha512-Yo/mKUNGqwbK/TIt/nXO8dgm+7HBbxlvMAG9l6tlNHJ7ChjeeGxnzJtx+1BWwNS2+REODkCdCU6/pE+FY3VmpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.100.0",
+  "version": "1.101.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/composables/helpers.js
+++ b/packages/core/src/composables/helpers.js
@@ -18,6 +18,7 @@ export const preventEventIfNotNumberInput = (event, options = {}) => {
       event.key.length > 1 &&
       !isNaN(event.key.substring(1))) ||
     event.metaKey ||
+    event.ctrlKey ||
     acceptedCharacters.includes(event.key)
   ) {
     return

--- a/packages/core/src/composables/helpers.js
+++ b/packages/core/src/composables/helpers.js
@@ -18,7 +18,7 @@ export const preventEventIfNotNumberInput = (event, options = {}) => {
       event.key.length > 1 &&
       !isNaN(event.key.substring(1))) ||
     event.metaKey ||
-    event.ctrlKey ||
+    (event.ctrlKey && !event.altKey) ||
     acceptedCharacters.includes(event.key)
   ) {
     return

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.100.0",
+  "version": "1.101.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.100.0",
+    "@orchidui/core": "1.101.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION
## Problem
On **Windows/Linux**, `PhoneInput` (and other consumers of the shared keydown helper) blocks **Ctrl+V** paste — users must type phone numbers by hand. Affects ~25 screens. macOS works because paste is Cmd+V.

## Root cause
`packages/core/src/composables/helpers.js` → `preventEventIfNotNumberInput` whitelists `event.metaKey` (Cmd) but **not** `event.ctrlKey`. So on Win/Linux, Ctrl+V is `preventDefault()`'d in keydown → the browser paste never fires → PhoneInput's working `onPaste` never runs.

## Fix
Add `event.ctrlKey` to the whitelist, symmetric with `event.metaKey`. Now Ctrl+V/C/A/X pass through on Win/Linux (clipboard/select shortcuts), and onPaste runs. One line.

## Version
Bumped core + dashboard 1.100.0 → 1.101.0 (lockfile synced).

## Note
Needs npm publish after merge (dev CI publish is currently broken — manual publish like 1.100.0), then dashboard bumps `@orchidui/dashboard` to 1.101.0 to consume.

## Test
On Windows/Linux: customer form → phone field → Ctrl+V a number → it pastes (country code parsed).