### PR TITLE
fix oc-tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.101.0",
+      "version": "1.102.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.101.0",
+      "version": "1.102.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.101.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.101.0.tgz",
+      "integrity": "sha512-pcR7rvgkqYvtAwglK6IUMGhzYg/xSL2VvIOzncn/qQBuglPPC15aJWx13YKr5NTYmaClkXZ4GJMRaGirQus0Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11184,30 +11184,13 @@
       "version": "1.102.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.101.0",
+        "@orchidui/core": "1.102.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
-      }
-    },
-    "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.101.0.tgz",
-      "integrity": "sha512-pcR7rvgkqYvtAwglK6IUMGhzYg/xSL2VvIOzncn/qQBuglPPC15aJWx13YKr5NTYmaClkXZ4GJMRaGirQus0Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8",
-        "dayjs": "^1.11.10",
-        "dexie": "^4.0.11",
-        "flag-icons": "^6.11.1",
-        "libphonenumber-js": "^1.10.51",
-        "lodash-es": "^4.17.21",
-        "v-calendar": "^3.1.2",
-        "vue-advanced-cropper": "^2.8.8",
-        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.101.0",
+  "version": "1.102.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Overlay/Tooltip/OcTooltip.stories.js
+++ b/packages/core/src/Overlay/Tooltip/OcTooltip.stories.js
@@ -59,3 +59,115 @@ export const Default = {
     `
   })
 }
+
+export const Placements = {
+  render: () => ({
+    components: { Tooltip, Theme },
+    template: `
+      <Theme>
+        <div class="w-full h-[500px] flex items-center justify-center">
+          <div class="grid grid-cols-3 gap-6 place-items-center">
+            <Tooltip position="top-start" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Top Start</button>
+              <template #popper>
+                <div class="p-3 text-sm">Top start tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="top" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Top</button>
+              <template #popper>
+                <div class="p-3 text-sm">Top tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="top-end" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Top End</button>
+              <template #popper>
+                <div class="p-3 text-sm">Top end tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="left" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Left</button>
+              <template #popper>
+                <div class="p-3 text-sm">Left tooltip</div>
+              </template>
+            </Tooltip>
+
+            <div class="px-4 py-2 bg-oc-gray-50 border border-oc-gray-200 rounded text-sm text-center text-oc-text-300 w-32 h-10 flex items-center justify-center">
+              center
+            </div>
+
+            <Tooltip position="right" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Right</button>
+              <template #popper>
+                <div class="p-3 text-sm">Right tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="bottom-start" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Bottom Start</button>
+              <template #popper>
+                <div class="p-3 text-sm">Bottom start tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="bottom" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Bottom</button>
+              <template #popper>
+                <div class="p-3 text-sm">Bottom tooltip</div>
+              </template>
+            </Tooltip>
+
+            <Tooltip position="bottom-end" :distance="10">
+              <button class="px-4 py-2 bg-oc-gray-100 rounded w-32">Bottom End</button>
+              <template #popper>
+                <div class="p-3 text-sm">Bottom end tooltip</div>
+              </template>
+            </Tooltip>
+          </div>
+        </div>
+      </Theme>
+    `
+  })
+}
+
+export const AttachToBody = {
+  render: () => ({
+    components: { Tooltip, Theme },
+    template: `
+      <Theme>
+        <div class="w-full h-[400px] flex items-center justify-center gap-6">
+          <Tooltip position="top" :distance="10" :is-attach-to-body="true">
+            <button class="px-4 py-2 bg-oc-gray-100 rounded">Top (body)</button>
+            <template #popper>
+              <div class="p-3 text-sm">Teleported to body — top</div>
+            </template>
+          </Tooltip>
+
+          <Tooltip position="bottom" :distance="10" :is-attach-to-body="true">
+            <button class="px-4 py-2 bg-oc-gray-100 rounded">Bottom (body)</button>
+            <template #popper>
+              <div class="p-3 text-sm">Teleported to body — bottom</div>
+            </template>
+          </Tooltip>
+
+          <Tooltip position="left" :distance="10" :is-attach-to-body="true">
+            <button class="px-4 py-2 bg-oc-gray-100 rounded">Left (body)</button>
+            <template #popper>
+              <div class="p-3 text-sm">Teleported to body — left</div>
+            </template>
+          </Tooltip>
+
+          <Tooltip position="right" :distance="10" :is-attach-to-body="true">
+            <button class="px-4 py-2 bg-oc-gray-100 rounded">Right (body)</button>
+            <template #popper>
+              <div class="p-3 text-sm">Teleported to body — right</div>
+            </template>
+          </Tooltip>
+        </div>
+      </Theme>
+    `
+  })
+}

--- a/packages/core/src/Overlay/Tooltip/OcTooltip.vue
+++ b/packages/core/src/Overlay/Tooltip/OcTooltip.vue
@@ -140,14 +140,7 @@ const onClickOutside = () => {
         <Transition :name="transitionName">
           <div v-show="isShow" ref="popperBodyEl" class="oc-tooltip" :class="popperClass">
             <slot name="popper" />
-            <div
-              v-if="!arrowHidden"
-              class="oc-arrow"
-              :class="{
-                '-top-2': isAttachToBody
-              }"
-              data-popper-arrow
-            />
+            <div v-if="!arrowHidden" class="oc-arrow" data-popper-arrow />
           </div>
         </Transition>
       </template>
@@ -160,29 +153,7 @@ const onClickOutside = () => {
   box-shadow:
     0 3px 22px 0 rgba(38, 42, 50, 0.09),
     0 1px 3px 0 rgba(0, 0, 0, 0.1);
-  @apply rounded-sm z-[1010];
-
-  &-wrapper {
-    div[data-popper-placement^='top'] .oc-arrow {
-      bottom: -4px;
-    }
-
-    div[data-popper-placement^='top'] .oc-arrow {
-      bottom: -4px;
-    }
-
-    div[data-popper-placement^='bottom'] .oc-arrow {
-      top: -4px;
-    }
-
-    div[data-popper-placement^='left'] .oc-arrow {
-      right: -4px;
-    }
-
-    div[data-popper-placement^='right'] .oc-arrow {
-      left: -4px;
-    }
-  }
+  @apply rounded-md z-[1010];
 
   .oc-arrow {
     @apply z-0;
@@ -209,5 +180,20 @@ const onClickOutside = () => {
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+</style>
+
+<style lang="scss">
+div[data-popper-placement^='top'] .oc-arrow {
+  bottom: -4px;
+}
+div[data-popper-placement^='bottom'] .oc-arrow {
+  top: -4px;
+}
+div[data-popper-placement^='left'] .oc-arrow {
+  right: -4px;
+}
+div[data-popper-placement^='right'] .oc-arrow {
+  left: -4px;
 }
 </style>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.101.0",
+  "version": "1.102.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.101.0",
+    "@orchidui/core": "1.102.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `OcTooltip` arrow placement so tooltips render correctly in all positions, including when `is-attach-to-body` is used. Adds Storybook examples to cover placements and teleport-to-body scenarios.

- **Bug Fixes**
  - Moved arrow offset styles to global `[data-popper-placement^="…"]` selectors so teleporting to `body` works reliably.
  - Simplified arrow markup (removed conditional `-top-2`) and updated container rounding to `rounded-md`.
  - Added stories for all placements and for `is-attach-to-body` to verify behavior.

- **Dependencies**
  - Published `@orchidui/core` and `@orchidui/dashboard` at `1.102.0`; `@orchidui/dashboard` now depends on `@orchidui/core@1.102.0`.

<sup>Written for commit 167666e8adad27e58ca944b14ac7013dc980a37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

