### PR TITLE
Bugfix/hit 18330 update dropdown transition and docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.102.0",
+      "version": "1.103.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,7 +11181,7 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.102.0",
+      "version": "1.103.0",
       "license": "MIT",
       "dependencies": {
         "@orchidui/core": "1.102.0",
@@ -11191,6 +11191,23 @@
         "quill": "^2.0.3",
         "quill-better-table": "^1.2.10",
         "shiki": "^1.29.2"
+      }
+    },
+    "packages/dashboard/node_modules/@orchidui/core": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.102.0.tgz",
+      "integrity": "sha512-iJcYNxWaZIz/tJioOpXLGtcwmB/njKAouMwS8Gz4CDhvBubfdgzQN46P7T5qW7z3RaWBlt2u7BfZXkfmKXvs+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "dayjs": "^1.11.10",
+        "dexie": "^4.0.11",
+        "flag-icons": "^6.11.1",
+        "libphonenumber-js": "^1.10.51",
+        "lodash-es": "^4.17.21",
+        "v-calendar": "^3.1.2",
+        "vue-advanced-cropper": "^2.8.8",
+        "vue-draggable-next": "^2.2.1"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Overlay/Dropdown/OcDropdown.stories.js
+++ b/packages/core/src/Overlay/Dropdown/OcDropdown.stories.js
@@ -1,95 +1,61 @@
-import { Dropdown, DropdownItem, Button, Icon, Theme } from '@/orchidui-core'
+import { Dropdown, DropdownItem, Button, Theme } from '@/orchidui-core'
 import { ref } from 'vue'
+import BasicExample from './examples/Basic.vue'
+import BasicRaw from './examples/Basic.vue?raw'
+import IconTriggerExample from './examples/IconTrigger.vue'
+import IconTriggerRaw from './examples/IconTrigger.vue?raw'
+import DropdownItemVariantsExample from './examples/DropdownItemVariants.vue'
+import DropdownItemVariantsRaw from './examples/DropdownItemVariants.vue?raw'
+import CustomMenuContentExample from './examples/CustomMenuContent.vue'
+import CustomMenuContentRaw from './examples/CustomMenuContent.vue?raw'
+import PlacementsExample from './examples/Placements.vue'
+import PlacementsRaw from './examples/Placements.vue?raw'
+import AttachToBodyExample from './examples/AttachToBody.vue'
+import AttachToBodyRaw from './examples/AttachToBody.vue?raw'
 
 export default {
   component: Dropdown,
   tags: ['autodocs'],
   kind: 'composite',
+  description: 'Floating menu panel attached to a trigger. Pair with DropdownItem for standard menu rows.',
+  keywords: ['dropdown', 'menu', 'popper', 'context menu', 'actions'],
   use_for: [
     'context menu',
     'row actions menu',
     'options dropdown',
     'action menu trigger'
   ],
-  understand_with: ['DropdownItem', 'Button', 'Icon'],
-  parameters: {
-    docs: {
-      description: {
-        component: `
-A floating menu panel attached to a trigger element. Use \`v-model\` to control open/close state. The trigger is the default slot; the menu content goes in \`#menu\`.
-
-Pair with \`DropdownItem\` for standard menu items, or use any custom content in the \`#menu\` slot.
-
----
-
-## Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| \`modelValue\` | Boolean | — | v-model — open/closed state |
-| \`placement\` | String | \`'bottom-start'\` | Popper.js placement: \`bottom-start\`, \`bottom-end\`, \`top-start\`, \`right\`, etc. |
-| \`distance\` | Number | \`4\` | Vertical offset between trigger and menu (px) |
-| \`skidding\` | Number | \`0\` | Horizontal offset between trigger and menu (px) |
-| \`isDisabled\` | Boolean | \`false\` | Disable — clicks on trigger do nothing |
-| \`menuClasses\` | String | — | Extra CSS class on the menu panel container |
-| \`maxMenuHeight\` | Number | — | Max height of menu panel (px) — auto-calculated if not set |
-| \`preventClickOutside\` | Boolean | \`false\` | Prevent closing when clicking outside |
-| \`isAttachToBody\` | Boolean | \`false\` | Teleport menu to body (use inside modals) |
-| \`popperStyle\` | Object | — | Inline styles on the popper element |
-| \`popperClass\` | String\\|Array\\|Object | — | CSS class on the popper wrapper |
-| \`popperOptions\` | Object | \`{}\` | Extra Popper.js options |
-
----
-
-## Events
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| \`update:modelValue\` | \`boolean\` | Open/close state changed |
-| \`scroll\` | \`Event\` | Menu panel scrolled |
-
----
-
-## Slots
-
-| Slot | Bindings | Description |
-|------|----------|-------------|
-| \`default\` | — | Trigger element — clicking this opens/closes the menu |
-| \`#menu\` | \`{ isPopoverOpen }\` | Menu content |
-
----
-
-## DropdownItem Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| \`text\` | String | — | Primary label |
-| \`subText\` | String | — | Secondary description below the label |
-| \`icon\` | String | — | Icon name on the left |
-| \`iconClasses\` | String | — | Extra class on the icon |
-| \`iconProps\` | Object | — | Extra attrs forwarded to Icon |
-| \`variant\` | String | \`'default'\` | \`'default'\` or \`'destructive'\` (red text) |
-| \`isBeta\` | Boolean | \`false\` | Show "BETA" badge |
-| \`isNew\` | Boolean | \`false\` | Show "NEW" badge |
-| \`isTryIt\` | Boolean | \`false\` | Show "TRY IT" badge |
-      `.trim()
-      }
-    }
-  }
+  understand_with: ['DropdownItem', 'Button', 'Icon']
 }
+
+// ── Playground ────────────────────────────────────────────────────────────────
 
 export const Playground = {
   argTypes: {
-    placement:   { control: 'select', options: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'right', 'left'] },
-    distance:    { control: 'number' },
-    isDisabled:  { control: 'boolean' },
-    menuClasses: { control: 'text' }
+    placement: {
+      control: 'select',
+      options: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'right', 'left']
+    },
+    distance: { control: 'number' },
+    skidding: { control: 'number' },
+    isDisabled: { control: 'boolean' },
+    isAttachToBody: { control: 'boolean' },
+    preventClickOutside: { control: 'boolean' },
+    menuClasses: { control: 'text' },
+    showDestructiveAction: {
+      control: 'boolean',
+      description: 'Show a destructive DropdownItem in a separate footer section'
+    }
   },
   args: {
     placement: 'bottom-start',
     distance: 4,
+    skidding: 0,
     isDisabled: false,
-    menuClasses: ''
+    isAttachToBody: false,
+    preventClickOutside: false,
+    menuClasses: '',
+    showDestructiveAction: true
   },
   render: (args) => ({
     components: { Dropdown, DropdownItem, Button, Theme },
@@ -98,20 +64,25 @@ export const Playground = {
       return { args, isOpen }
     },
     template: `
-      <Theme class="p-6 h-[300px]">
+      <Theme class="p-6 h-[320px]">
         <Dropdown v-model="isOpen" v-bind="args">
-          <Button label="Open menu" variant="secondary" />
+          <Button label="Open menu" variant="secondary" :is-disabled="args.isDisabled" />
+
           <template #menu>
             <div class="flex flex-col p-2">
               <DropdownItem text="Edit" icon="pencil" @click="isOpen = false" />
               <DropdownItem text="Duplicate" icon="copy" @click="isOpen = false" />
               <DropdownItem text="Archive" icon="archive" @click="isOpen = false" />
             </div>
-            <div class="p-2 border-t border-oc-gray-100">
+            <div v-if="args.showDestructiveAction" class="p-2 border-t border-oc-gray-100">
               <DropdownItem text="Delete" icon="bin" variant="destructive" @click="isOpen = false" />
             </div>
           </template>
         </Dropdown>
+
+        <p class="mt-4 text-xs text-oc-text-400 font-mono">
+          placement → {{ args.placement }}
+        </p>
       </Theme>
     `
   })
@@ -119,169 +90,84 @@ export const Playground = {
 
 export const Basic = {
   description: 'Standard action menu with grouped DropdownItems. Destructive actions go in a separate section.',
-  highlights: ['v-model — controls open/close', '#menu slot — menu content', 'DropdownItem with variant="destructive" — red text'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Dropdown, DropdownItem, Button } from '@orchidui/core'
-
-const isOpen = ref(false)
-
-const onEdit    = () => { /* ... */ isOpen.value = false }
-const onDelete  = () => { /* ... */ isOpen.value = false }
-</script>
-
-<template>
-  <Dropdown v-model="isOpen" placement="bottom-end">
-    <Button label="Actions" variant="secondary" />
-
-    <template #menu>
-      <div class="flex flex-col p-2">
-        <DropdownItem text="Edit"      icon="pencil"  @click="onEdit" />
-        <DropdownItem text="Duplicate" icon="copy" />
-        <DropdownItem text="Archive"   icon="archive" />
-      </div>
-      <div class="p-2 border-t border-oc-gray-100">
-        <DropdownItem text="Delete" icon="bin" variant="destructive" @click="onDelete" />
-      </div>
-    </template>
-  </Dropdown>
-</template>`,
+  highlights: [
+    'v-model — controls open/close',
+    '#menu slot — menu content',
+    'placement="bottom-end" — aligns menu to the trigger edge',
+    'DropdownItem with variant="destructive" — red text'
+  ],
+  code: BasicRaw,
   render: () => ({
-    components: { Dropdown, DropdownItem, Button, Theme },
-    setup() {
-      const isOpen = ref(false)
-      return { isOpen }
-    },
-    template: `
-      <Theme class="p-6 h-[260px]">
-        <Dropdown v-model="isOpen" placement="bottom-end">
-          <Button label="Actions" variant="secondary" />
-          <template #menu>
-            <div class="flex flex-col p-2">
-              <DropdownItem text="Edit"      icon="pencil" />
-              <DropdownItem text="Duplicate" icon="copy" />
-              <DropdownItem text="Archive"   icon="archive" />
-            </div>
-            <div class="p-2 border-t border-oc-gray-100">
-              <DropdownItem text="Delete" icon="bin" variant="destructive" />
-            </div>
-          </template>
-        </Dropdown>
-      </Theme>
-    `
+    components: { BasicExample },
+    template: `<div class="p-6"><BasicExample /></div>`
   })
 }
 
 export const IconTrigger = {
   description: 'Use a three-dot icon as the trigger — common in table action cells.',
-  highlights: ['Icon component as trigger', 'cursor-pointer on the trigger', 'placement="bottom-end" — aligns right'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Dropdown, DropdownItem, Icon } from '@orchidui/core'
-
-const isOpen = ref(false)
-</script>
-
-<template>
-  <Dropdown v-model="isOpen" placement="bottom-end">
-    <Icon name="dots-vertical" class="cursor-pointer text-oc-text-400" />
-
-    <template #menu>
-      <div class="flex flex-col p-2">
-        <DropdownItem text="View details" icon="eye" />
-        <DropdownItem text="Edit"         icon="pencil" />
-        <DropdownItem text="Delete"       icon="bin" variant="destructive" />
-      </div>
-    </template>
-  </Dropdown>
-</template>`,
+  highlights: [
+    'Icon component as trigger',
+    'cursor-pointer on the trigger',
+    'placement="bottom-end" — aligns right in tight layouts'
+  ],
+  code: IconTriggerRaw,
   render: () => ({
-    components: { Dropdown, DropdownItem, Icon, Theme },
-    setup() {
-      const isOpen = ref(false)
-      return { isOpen }
-    },
-    template: `
-      <Theme class="p-6 h-[220px] flex justify-center">
-        <Dropdown v-model="isOpen" placement="bottom-end">
-          <Icon name="dots-vertical" class="cursor-pointer text-oc-text-400 w-6 h-6" />
-          <template #menu>
-            <div class="flex flex-col p-2">
-              <DropdownItem text="View details" icon="eye" />
-              <DropdownItem text="Edit"         icon="pencil" />
-              <DropdownItem text="Delete"       icon="bin" variant="destructive" />
-            </div>
-          </template>
-        </Dropdown>
-      </Theme>
-    `
+    components: { IconTriggerExample },
+    template: `<div class="p-6"><IconTriggerExample /></div>`
   })
 }
 
 export const DropdownItemVariants = {
   description: 'DropdownItem variants — icon, subText, badges (NEW, BETA, TRY IT), and destructive.',
-  highlights: ['subText — description below the label', 'isBeta / isNew / isTryIt — badge labels', 'variant="destructive" — red text'],
+  highlights: [
+    'subText — description below the label',
+    'isBeta / isNew / isTryIt — badge labels',
+    'variant="destructive" — red text'
+  ],
+  code: DropdownItemVariantsRaw,
   render: () => ({
-    components: { Dropdown, DropdownItem, Button, Theme },
-    setup() {
-      const isOpen = ref(true)
-      return { isOpen }
-    },
-    template: `
-      <Theme class="p-6 h-[400px]">
-        <Dropdown v-model="isOpen">
-          <Button label="Menu" variant="secondary" />
-          <template #menu>
-            <div class="flex flex-col p-2 min-w-[220px]">
-              <DropdownItem text="Standard item"  icon="check" />
-              <DropdownItem text="With sub text"  icon="info-circle" sub-text="More details here" />
-              <DropdownItem text="New feature"    icon="star" is-new />
-              <DropdownItem text="Beta feature"   icon="zap" is-beta />
-              <DropdownItem text="Try it"         icon="play" is-try-it />
-            </div>
-            <div class="p-2 border-t border-oc-gray-100">
-              <DropdownItem text="Destructive action" icon="bin" variant="destructive" />
-            </div>
-          </template>
-        </Dropdown>
-      </Theme>
-    `
+    components: { DropdownItemVariantsExample },
+    template: `<div class="p-6"><DropdownItemVariantsExample /></div>`
   })
 }
 
 export const CustomMenuContent = {
   description: 'The #menu slot accepts any content — not just DropdownItems. Use for custom panels like user profile menus.',
-  highlights: ['#menu slot — any HTML/component', 'isAttachToBody — required inside modals with overflow:hidden'],
+  highlights: [
+    '#menu slot — any HTML/component',
+    'placement="bottom-end" — keeps wide panels aligned to the trigger'
+  ],
+  code: CustomMenuContentRaw,
   render: () => ({
-    components: { Dropdown, Button, Icon, Theme },
-    setup() {
-      const isOpen = ref(false)
-      return { isOpen }
-    },
-    template: `
-      <Theme class="p-6 h-[280px]">
-        <Dropdown v-model="isOpen" placement="bottom-end">
-          <Button label="Account" variant="secondary" left-icon="user" />
-          <template #menu>
-            <div class="min-w-[220px]">
-              <div class="p-4 border-b border-oc-gray-100">
-                <p class="font-medium text-sm">Alice Smith</p>
-                <p class="text-xs text-oc-text-400">alice@example.com</p>
-              </div>
-              <div class="p-2 flex flex-col">
-                <div class="flex items-center gap-3 p-3 rounded cursor-pointer hover:bg-oc-accent-1-50 text-sm">
-                  <Icon name="settings" class="w-5 h-5 text-oc-text-400" />
-                  <span>Settings</span>
-                </div>
-                <div class="flex items-center gap-3 p-3 rounded cursor-pointer hover:bg-oc-accent-1-50 text-sm text-oc-error">
-                  <Icon name="logout" class="w-5 h-5" />
-                  <span>Sign out</span>
-                </div>
-              </div>
-            </div>
-          </template>
-        </Dropdown>
-      </Theme>
-    `
+    components: { CustomMenuContentExample },
+    template: `<div class="p-6"><CustomMenuContentExample /></div>`
+  })
+}
+
+export const Placements = {
+  description: 'All supported placement values with placement-aware enter/leave animation. Each trigger opens its own menu so you can compare positioning and motion direction.',
+  highlights: [
+    'placement — bottom-start, bottom-end, top-start, top-end, right, left',
+    'Each placement uses a different transform-origin and slide direction',
+    'distance / skidding — fine-tune offset from the trigger'
+  ],
+  code: PlacementsRaw,
+  render: () => ({
+    components: { PlacementsExample },
+    template: `<div class="p-6"><PlacementsExample /></div>`
+  })
+}
+
+export const AttachToBody = {
+  description: 'Teleport the menu to document.body when the trigger sits inside overflow:hidden containers such as modals or scrollable panels.',
+  highlights: [
+    'isAttachToBody — renders menu outside the parent overflow context',
+    'Required inside modals with overflow:hidden',
+    'Works with all placement values'
+  ],
+  code: AttachToBodyRaw,
+  render: () => ({
+    components: { AttachToBodyExample },
+    template: `<div class="p-6"><AttachToBodyExample /></div>`
   })
 }

--- a/packages/core/src/Overlay/Dropdown/OcDropdown.vue
+++ b/packages/core/src/Overlay/Dropdown/OcDropdown.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Popper } from '@/orchidui-core'
 import { clickOutside as vClickOutside } from '../../directives/clickOutside.js'
-import { ref, watch, onMounted } from 'vue' // Import the directive
+import { ref, watch, onMounted, computed } from 'vue'
 
 const emit = defineEmits({
   /** Dropdown open/close state changed. Payload: new boolean state. */
@@ -102,6 +102,19 @@ defineExpose({
 
 const isFixed = ref(false)
 
+const menuAnimationClass = computed(() => {
+  const placement = props.placement
+
+  if (placement.startsWith('top')) {
+    return placement.endsWith('-end') ? 'oc-dropdown-menu--top-end' : 'oc-dropdown-menu--top-start'
+  }
+
+  if (placement.startsWith('right')) return 'oc-dropdown-menu--right'
+  if (placement.startsWith('left')) return 'oc-dropdown-menu--left'
+
+  return placement.endsWith('-end') ? 'oc-dropdown-menu--bottom-end' : 'oc-dropdown-menu--bottom-start'
+})
+
 onMounted(() => {
   if (parentElement.value.closest('#modal-overlay-wrapper')) {
     isFixed.value = true
@@ -132,8 +145,8 @@ onMounted(() => {
           <div
             v-show="modelValue"
             ref="dropdownScroll"
-            :class="menuClasses"
-            class="rounded bg-oc-bg-light shadow min-w-[162px] overflow-y-auto"
+            :class="[menuClasses, menuAnimationClass]"
+            class="oc-dropdown-menu rounded bg-oc-bg-light shadow min-w-[162px] overflow-y-auto"
             :style="{
               maxHeight: (maxMenuHeight || maxPopperHeight) - 68 + 'px'
             }"
@@ -148,13 +161,77 @@ onMounted(() => {
 </template>
 
 <style scoped lang="scss">
-.dropdown-fade-enter-active,
-.dropdown-fade-leave-active {
-  transition: opacity 0.3s ease;
+.dropdown-fade-enter-active {
+  transition:
+    opacity 0.18s ease-out,
+    transform 0.18s ease-out;
+  will-change: opacity, transform;
 }
 
-.dropdown-fade-enter-from,
-.dropdown-fade-leave-to {
-  opacity: 0;
+.dropdown-fade-leave-active {
+  transition:
+    opacity 0.13s ease-in,
+    transform 0.13s ease-in;
+  will-change: opacity, transform;
+}
+
+.oc-dropdown-menu--bottom-start {
+  transform-origin: top left;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateY(-4px);
+  }
+}
+
+.oc-dropdown-menu--bottom-end {
+  transform-origin: top right;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateY(-4px);
+  }
+}
+
+.oc-dropdown-menu--top-start {
+  transform-origin: bottom left;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateY(4px);
+  }
+}
+
+.oc-dropdown-menu--top-end {
+  transform-origin: bottom right;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateY(4px);
+  }
+}
+
+.oc-dropdown-menu--right {
+  transform-origin: left center;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateX(-4px);
+  }
+}
+
+.oc-dropdown-menu--left {
+  transform-origin: right center;
+
+  &.dropdown-fade-enter-from,
+  &.dropdown-fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95) translateX(4px);
+  }
 }
 </style>

--- a/packages/core/src/Overlay/Dropdown/examples/AttachToBody.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/AttachToBody.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, DropdownItem, Button, Theme } from '@orchidui/core'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <Theme class="h-[280px]">
+    <div class="h-[200px] overflow-hidden rounded-lg border border-oc-gray-200 p-4">
+      <p class="mb-4 text-xs text-oc-text-400">
+        Parent has <code class="font-mono">overflow: hidden</code>. Use
+        <code class="font-mono">is-attach-to-body</code> so the menu is not clipped.
+      </p>
+
+      <Dropdown v-model="isOpen" placement="bottom-start" is-attach-to-body>
+        <Button label="Open in modal-like container" variant="secondary" />
+
+        <template #menu>
+          <div class="flex flex-col p-2 min-w-[200px]">
+            <DropdownItem text="Edit" icon="pencil" @click="isOpen = false" />
+            <DropdownItem text="Archive" icon="archive" @click="isOpen = false" />
+            <DropdownItem text="Delete" icon="bin" variant="destructive" @click="isOpen = false" />
+          </div>
+        </template>
+      </Dropdown>
+    </div>
+  </Theme>
+</template>

--- a/packages/core/src/Overlay/Dropdown/examples/Basic.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/Basic.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, DropdownItem, Button, Theme } from '@orchidui/core'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <Theme class="h-[260px]">
+    <Dropdown v-model="isOpen" placement="bottom-end">
+      <Button label="Actions" variant="secondary" />
+
+      <template #menu>
+        <div class="flex flex-col p-2">
+          <DropdownItem text="Edit" icon="pencil" @click="isOpen = false" />
+          <DropdownItem text="Duplicate" icon="copy" @click="isOpen = false" />
+          <DropdownItem text="Archive" icon="archive" @click="isOpen = false" />
+        </div>
+        <div class="p-2 border-t border-oc-gray-100">
+          <DropdownItem text="Delete" icon="bin" variant="destructive" @click="isOpen = false" />
+        </div>
+      </template>
+    </Dropdown>
+  </Theme>
+</template>

--- a/packages/core/src/Overlay/Dropdown/examples/CustomMenuContent.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/CustomMenuContent.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, Button, Icon, Theme } from '@orchidui/core'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <Theme class="h-[280px]">
+    <Dropdown v-model="isOpen" placement="bottom-end">
+      <Button label="Account" variant="secondary" left-icon="user" />
+
+      <template #menu>
+        <div class="min-w-[220px]">
+          <div class="p-4 border-b border-oc-gray-100">
+            <p class="font-medium text-sm">Alice Smith</p>
+            <p class="text-xs text-oc-text-400">alice@example.com</p>
+          </div>
+          <div class="p-2 flex flex-col">
+            <div
+              class="flex items-center gap-3 p-3 rounded cursor-pointer hover:bg-oc-accent-1-50 text-sm"
+              @click="isOpen = false"
+            >
+              <Icon name="settings" class="w-5 h-5 text-oc-text-400" />
+              <span>Settings</span>
+            </div>
+            <div
+              class="flex items-center gap-3 p-3 rounded cursor-pointer hover:bg-oc-accent-1-50 text-sm text-oc-error"
+              @click="isOpen = false"
+            >
+              <Icon name="logout" class="w-5 h-5" />
+              <span>Sign out</span>
+            </div>
+          </div>
+        </div>
+      </template>
+    </Dropdown>
+  </Theme>
+</template>

--- a/packages/core/src/Overlay/Dropdown/examples/DropdownItemVariants.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/DropdownItemVariants.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, DropdownItem, Button, Theme } from '@orchidui/core'
+
+const isOpen = ref(true)
+</script>
+
+<template>
+  <Theme class="h-[400px]">
+    <Dropdown v-model="isOpen">
+      <Button label="Menu" variant="secondary" />
+
+      <template #menu>
+        <div class="flex flex-col p-2 min-w-[220px]">
+          <DropdownItem text="Standard item" icon="check" />
+          <DropdownItem text="With sub text" icon="info-circle" sub-text="More details here" />
+          <DropdownItem text="New feature" icon="star" is-new />
+          <DropdownItem text="Beta feature" icon="zap" is-beta />
+          <DropdownItem text="Try it" icon="play" is-try-it />
+        </div>
+        <div class="p-2 border-t border-oc-gray-100">
+          <DropdownItem text="Destructive action" icon="bin" variant="destructive" />
+        </div>
+      </template>
+    </Dropdown>
+  </Theme>
+</template>

--- a/packages/core/src/Overlay/Dropdown/examples/IconTrigger.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/IconTrigger.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, DropdownItem, Icon, Theme } from '@orchidui/core'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <Theme class="h-[220px] flex justify-center">
+    <Dropdown v-model="isOpen" placement="bottom-end">
+      <Icon name="dots-vertical" class="cursor-pointer text-oc-text-400 w-6 h-6" />
+
+      <template #menu>
+        <div class="flex flex-col p-2">
+          <DropdownItem text="View details" icon="eye" @click="isOpen = false" />
+          <DropdownItem text="Edit" icon="pencil" @click="isOpen = false" />
+          <DropdownItem text="Delete" icon="bin" variant="destructive" @click="isOpen = false" />
+        </div>
+      </template>
+    </Dropdown>
+  </Theme>
+</template>

--- a/packages/core/src/Overlay/Dropdown/examples/Placements.vue
+++ b/packages/core/src/Overlay/Dropdown/examples/Placements.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { ref } from 'vue'
+import { Dropdown, DropdownItem, Button, Theme } from '@orchidui/core'
+
+const openByPlacement = ref({})
+
+const placements = [
+  { placement: 'top-start', label: 'top-start', position: 'absolute top-6 left-6' },
+  { placement: 'top-end', label: 'top-end', position: 'absolute top-6 right-6' },
+  { placement: 'bottom-start', label: 'bottom-start', position: 'absolute bottom-6 left-6' },
+  { placement: 'bottom-end', label: 'bottom-end', position: 'absolute bottom-6 right-6' },
+  { placement: 'left', label: 'left', position: 'absolute top-1/2 left-6 -translate-y-1/2' },
+  { placement: 'right', label: 'right', position: 'absolute top-1/2 right-6 -translate-y-1/2' }
+]
+
+function isOpen(placement) {
+  return openByPlacement.value[placement] ?? false
+}
+
+function setOpen(placement, value) {
+  openByPlacement.value = { ...openByPlacement.value, [placement]: value }
+}
+</script>
+
+<template>
+  <Theme>
+    <div
+      class="relative mx-auto h-[420px] w-full max-w-[720px] rounded-lg border border-dashed border-oc-gray-200 bg-oc-bg-2"
+    >
+      <p class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-xs text-oc-text-400">
+        Click each trigger to preview placement animation
+      </p>
+
+      <div v-for="item in placements" :key="item.placement" :class="item.position">
+        <Dropdown
+          :model-value="isOpen(item.placement)"
+          :placement="item.placement"
+          @update:model-value="setOpen(item.placement, $event)"
+        >
+          <Button :label="item.label" size="small" variant="secondary" />
+
+          <template #menu>
+            <div class="flex flex-col p-2 min-w-[160px]">
+              <DropdownItem text="Edit" icon="pencil" @click="setOpen(item.placement, false)" />
+              <DropdownItem text="Duplicate" icon="copy" @click="setOpen(item.placement, false)" />
+              <DropdownItem
+                text="Delete"
+                icon="bin"
+                variant="destructive"
+                @click="setOpen(item.placement, false)"
+              />
+            </div>
+          </template>
+        </Dropdown>
+      </div>
+    </div>
+  </Theme>
+</template>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.102.0",
+    "@orchidui/core": "1.103.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns `OcDropdown` transitions with the Sidebar Navigation v3 prototype (Linear HIT-18330), adding placement-aware motion and smoother timing. Also refreshes Storybook docs/examples and bumps `@orchidui/core` and `@orchidui/dashboard` to 1.103.0.

- **Bug Fixes**
  - Placement-aware enter/leave animations with correct transform-origin for top/bottom/left/right; eased timings for smoother open/close.
  - Keeps existing API (`placement`, `distance`, `skidding`) unchanged while matching the prototype behavior.

- **Refactors**
  - Reworked stories into focused examples: Basic, IconTrigger, DropdownItemVariants, CustomMenuContent, Placements, AttachToBody.
  - Added controls for `skidding`, `isAttachToBody`, and `preventClickOutside`, and simplified docs text.

<sup>Written for commit 603f9cb45edde3ed122379fd74efb166483367a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

