### PR TITLE
Chore/file uploader resetting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.103.0",
+      "version": "1.104.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.103.0",
+      "version": "1.104.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.102.0",
+        "@orchidui/core": "1.103.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.102.0.tgz",
-      "integrity": "sha512-iJcYNxWaZIz/tJioOpXLGtcwmB/njKAouMwS8Gz4CDhvBubfdgzQN46P7T5qW7z3RaWBlt2u7BfZXkfmKXvs+Q==",
+      "version": "1.103.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.103.0.tgz",
+      "integrity": "sha512-YqxlUcdQa87YZIWoA8kIPY1XNKNtn7IYoOvurZR9FhWj7Yya8t+BIDljSQi4COfppKg/zl5sxs2WpD7oKBbjww==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.103.0",
+  "version": "1.104.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/composables/uploadFileProgress.js
+++ b/packages/core/src/composables/uploadFileProgress.js
@@ -40,6 +40,11 @@ export const useUploadFileProgress = (
       }
     })
 
+    // Reset the input value so selecting the same file again re-fires `change`.
+    // Without this, re-uploading an identical file (e.g. after it was rejected
+    // for exceeding maxSize) produces no event and no re-validation.
+    if (event.target) event.target.value = ''
+
     isErrorMaxSize.value =
       uploadFiles.reduce((acc, file) => acc + file.size, 0) > maxSize * 1024 * 1024
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.103.0",
+  "version": "1.104.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.103.0",
+    "@orchidui/core": "1.104.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reset the file input in `useUploadFileProgress` so selecting the same file triggers a new change event. This restores re-validation for files previously rejected (e.g., over maxSize).

- **Dependencies**
  - Bumped `@orchidui/core` and `@orchidui/dashboard` to `1.104.0`, and aligned `@orchidui/dashboard` to depend on `@orchidui/core@1.104.0`.

<sup>Written for commit 50894fd9c1318f34647641042efdcf725e31076f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

