### PR TITLE
Chore/file uploader resetting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.104.0",
+      "version": "1.105.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.104.0",
+      "version": "1.105.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.103.0",
+        "@orchidui/core": "1.104.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.103.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.103.0.tgz",
-      "integrity": "sha512-YqxlUcdQa87YZIWoA8kIPY1XNKNtn7IYoOvurZR9FhWj7Yya8t+BIDljSQi4COfppKg/zl5sxs2WpD7oKBbjww==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.104.0.tgz",
+      "integrity": "sha512-aNbwyElWP/bwULuyL24Wyup7fHgcr5nc8HoTJFEAXpON76kk11RpBZR3yjY7wpvYnHAPomQveEl+dIkzTO1iyg==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Form/SingleFileUpload/OcSingleFileUpload.vue
+++ b/packages/core/src/Form/SingleFileUpload/OcSingleFileUpload.vue
@@ -189,6 +189,7 @@ defineExpose({
       :accept="accept"
       :uploaded-image="currentFile"
       :image-classes="imageClasses"
+      :allow-to-edit="allowToEdit"
       :show-upload-image-area="showUploadImageArea"
       @update:uploaded-image="onUploadImage"
       @change="onChangeFile($event, props.format === 'object')"

--- a/packages/core/src/Form/SingleFileUpload/OcSingleOnlyImageUpload.vue
+++ b/packages/core/src/Form/SingleFileUpload/OcSingleOnlyImageUpload.vue
@@ -16,7 +16,7 @@ const props = defineProps({
     type: String,
     default: ''
   },
-  showUploadImageArea: Boolean
+  showUploadImageArea: Boolean,
   allowToEdit: Boolean
 })
 const emit = defineEmits(['change', 'update:uploadedImage', 'onOpenEditImage', 'delete'])

--- a/packages/core/src/Form/SingleFileUpload/OcSingleOnlyImageUpload.vue
+++ b/packages/core/src/Form/SingleFileUpload/OcSingleOnlyImageUpload.vue
@@ -17,6 +17,7 @@ const props = defineProps({
     default: ''
   },
   showUploadImageArea: Boolean
+  allowToEdit: Boolean
 })
 const emit = defineEmits(['change', 'update:uploadedImage', 'onOpenEditImage', 'delete'])
 const isDropdownOpen = ref(false)
@@ -93,7 +94,7 @@ const openEditImage = () => {
         />
         <template #menu>
           <div class="py-2 flex flex-col">
-            <div class="flex p-3 cursor-pointer items-center gap-x-3" @click="openEditImage">
+            <div v-if="allowToEdit" class="flex p-3 cursor-pointer items-center gap-x-3" @click="openEditImage">
               <Icon width="16" height="16" name="pencil" />
               <span>Edit Image</span>
             </div>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.104.0",
+    "@orchidui/core": "1.105.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an allowToEdit prop to the single image uploader so teams can hide the “Edit Image” action when editing isn’t allowed. The prop is passed from `OcSingleFileUpload` to `OcSingleOnlyImageUpload`.

- New Features
  - Added allowToEdit to OcSingleOnlyImageUpload and gated the “Edit Image” menu item.
  - Passed allowToEdit from OcSingleFileUpload to the image uploader.

- Dependencies
  - Bumped `@orchidui/core` and `@orchidui/dashboard` to 1.105.0, and updated dashboard’s `@orchidui/core` dependency to 1.105.0.

<sup>Written for commit c83f9204dc4e18e5e5a187cb33b4d01dcfb78116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

