### PR TITLE
update chart & tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.105.0",
+      "version": "1.106.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.105.0",
+      "version": "1.106.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.104.0",
+        "@orchidui/core": "1.105.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.104.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.104.0.tgz",
-      "integrity": "sha512-aNbwyElWP/bwULuyL24Wyup7fHgcr5nc8HoTJFEAXpON76kk11RpBZR3yjY7wpvYnHAPomQveEl+dIkzTO1iyg==",
+      "version": "1.105.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.105.0.tgz",
+      "integrity": "sha512-oMafZrBAjK9oaZppXSe5hfuIkNOE7Tbt38r9iF4Cmg+c9MPSDJK89+LpJcQ15+jYcdQHTKq/b8RCBwW3cjID/A==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.105.0",
+  "version": "1.106.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
+++ b/packages/core/src/DataDisplay/NewTable/OcNewTable.vue
@@ -118,7 +118,7 @@
             <tr>
               <td>
                 <div
-                  :style="{ width: scrollContainerRef?.offsetWidth + 'px' }"
+                  :style="loadingCellStyle"
                   class="flex flex-col justify-center items-center py-10 gap-y-4 bg-white relative z-100"
                 >
                   <Icon
@@ -186,6 +186,15 @@ const props = defineProps({
   isLoading: {
     type: Boolean,
     default: false
+  },
+  /**
+   * Number of rows worth of height to reserve while loading, so the table keeps
+   * its populated height (matching the design) instead of collapsing to a small
+   * spinner and jumping when data arrives.
+   */
+  loadingRows: {
+    type: Number,
+    default: 0
   },
   /**
    * Rows that cannot be selected. Array of row data objects, matched against
@@ -260,6 +269,17 @@ let pageX = null
 let curColWidth = null
 let nxtColWidth = null
 const isScrolledToLeft = ref(true)
+
+// Approximate height of a single populated row, used to reserve space so the
+// loading state matches the eventual table height.
+const LOADING_ROW_HEIGHT = 44
+
+const loadingCellStyle = computed(() => ({
+  width: scrollContainerRef.value?.offsetWidth
+    ? `${scrollContainerRef.value.offsetWidth}px`
+    : undefined,
+  ...(props.loadingRows ? { minHeight: `${props.loadingRows * LOADING_ROW_HEIGHT}px` } : {})
+}))
 
 const showLoadingText = ref(false)
 let loadingTimeout = null

--- a/packages/core/src/Overlay/Tooltip/OcTooltip.vue
+++ b/packages/core/src/Overlay/Tooltip/OcTooltip.vue
@@ -156,18 +156,16 @@ const onClickOutside = () => {
   @apply rounded-md z-[1010];
 
   .oc-arrow {
-    @apply z-0;
+    @apply absolute z-0 h-3 w-3 bg-inherit;
     visibility: hidden;
 
-    &,
+    // Drawn as a real triangle (via clip-path) that sits flush against the panel
+    // edge, so it points cleanly without overlapping the tooltip text. The size,
+    // shape and offset per placement are defined in the unscoped block below.
     &::before {
-      @apply absolute w-3 h-3  bg-inherit;
-    }
-
-    &::before {
+      @apply absolute bg-inherit;
       visibility: visible;
       content: '';
-      transform: rotate(45deg);
     }
   }
 }
@@ -184,16 +182,50 @@ const onClickOutside = () => {
 </style>
 
 <style lang="scss">
+// Each placement draws a triangle whose base is flush with the panel edge and
+// whose tip points toward the trigger, so it never covers the tooltip content.
 div[data-popper-placement^='top'] .oc-arrow {
-  bottom: -4px;
+  bottom: 0;
+
+  &::before {
+    top: 100%;
+    left: 0;
+    width: 12px;
+    height: 6px;
+    clip-path: polygon(0 0, 100% 0, 50% 100%);
+  }
 }
 div[data-popper-placement^='bottom'] .oc-arrow {
-  top: -4px;
+  top: 0;
+
+  &::before {
+    bottom: 100%;
+    left: 0;
+    width: 12px;
+    height: 6px;
+    clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  }
 }
 div[data-popper-placement^='left'] .oc-arrow {
-  right: -4px;
+  right: 0;
+
+  &::before {
+    left: 100%;
+    top: 0;
+    width: 6px;
+    height: 12px;
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
+  }
 }
 div[data-popper-placement^='right'] .oc-arrow {
-  left: -4px;
+  left: 0;
+
+  &::before {
+    right: 100%;
+    top: 0;
+    width: 6px;
+    height: 12px;
+    clip-path: polygon(100% 0, 0 50%, 100% 100%);
+  }
 }
 </style>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.105.0",
+  "version": "1.106.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.105.0",
+    "@orchidui/core": "1.106.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/src/Dashboard/Charts/OverviewMonthlyBarChart/OcOverviewMonthlyBarChart.vue
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewMonthlyBarChart/OcOverviewMonthlyBarChart.vue
@@ -112,7 +112,13 @@ const chartOptions = computed(() => ({
     top: '20',
     containLabel: true
   },
-  animation: false,
+  // Animate on first render and whenever the data updates so bars grow up from
+  // the baseline (e.g. from a zero/empty state into their real values).
+  animation: true,
+  animationDuration: 800,
+  animationDurationUpdate: 800,
+  animationEasing: 'cubicOut',
+  animationEasingUpdate: 'cubicOut',
 
   series: [{
     id: 'myBar',

--- a/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
+++ b/packages/dashboard/src/Dashboard/Charts/OverviewPieChart/OcOverviewPieChart.vue
@@ -103,7 +103,13 @@ const chartOptions = computed(() => ({
         borderColor: '#fff',
         borderWidth: 2
       },
-      animation: false,
+      // Animate the ring on first render and on data updates so slices sweep in
+      // instead of appearing instantly.
+      animation: true,
+      animationDuration: 800,
+      animationDurationUpdate: 800,
+      animationEasing: 'cubicOut',
+      animationEasingUpdate: 'cubicOut',
       label: {
         show: false // Hide default labels
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable smooth chart animations, rework the tooltip arrow to avoid covering content, and add a `loadingRows` option to keep table layout stable while data loads.

- **New Features**
  - Charts: Turned on ECharts animations (800ms, cubicOut) for the monthly bar and pie charts on initial render and updates.
  - `@orchidui/core` `OcNewTable`: Added `loadingRows` prop to reserve height during loading and prevent layout jumps.

- **Bug Fixes**
  - Tooltip: Replaced the rotated square arrow with a clip‑path triangle per placement, so the arrow sits flush with the panel and doesn’t overlap tooltip text.

<sup>Written for commit e59f0296cd87b33390b2f4058845e09198f92d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

