### PR TITLE
clear file after emit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.106.0",
+      "version": "1.107.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.106.0",
+      "version": "1.107.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.105.0",
+        "@orchidui/core": "1.106.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.105.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.105.0.tgz",
-      "integrity": "sha512-oMafZrBAjK9oaZppXSe5hfuIkNOE7Tbt38r9iF4Cmg+c9MPSDJK89+LpJcQ15+jYcdQHTKq/b8RCBwW3cjID/A==",
+      "version": "1.106.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.106.0.tgz",
+      "integrity": "sha512-JLnyVW2bwMF7RtPgXAv3nbuzrW9T88j4BCclgvomkaXeG8Goa10SoYQ0cxipCE3j2rAcmcfmUWsTZtRXKH7kNw==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/composables/uploadFileProgress.js
+++ b/packages/core/src/composables/uploadFileProgress.js
@@ -43,7 +43,15 @@ export const useUploadFileProgress = (
     // Reset the input value so selecting the same file again re-fires `change`.
     // Without this, re-uploading an identical file (e.g. after it was rejected
     // for exceeding maxSize) produces no event and no re-validation.
-    if (event.target) event.target.value = ''
+    // Deferred so listeners that read `event.target.files` during this same
+    // event (e.g. bubbling native `change` handlers) still see the selected
+    // files before the input is cleared.
+    const inputEl = event.target
+    if (inputEl) {
+      setTimeout(() => {
+        inputEl.value = ''
+      })
+    }
 
     isErrorMaxSize.value =
       uploadFiles.reduce((acc, file) => acc + file.size, 0) > maxSize * 1024 * 1024

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.106.0",
+    "@orchidui/core": "1.107.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes file uploads by clearing the input after the change event, so listeners can read `event.target.files` and reselecting the same file works reliably.

- **Bug Fixes**
  - Defer clearing the file input with `setTimeout` in `useUploadFileProgress`, preventing early clearing that broke native/bubbling handlers.

- **Dependencies**
  - Bump `@orchidui/core` and `@orchidui/dashboard` to `1.107.0`.
  - Update dashboard to depend on `@orchidui/core@1.107.0`.

<sup>Written for commit 49a96671342778af99db33fb67799ba7a7c0c201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

