### PR TITLE
Table: add slot before search option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.107.0",
+      "version": "1.108.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.107.0",
+      "version": "1.108.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.106.0",
+        "@orchidui/core": "1.107.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.106.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.106.0.tgz",
-      "integrity": "sha512-JLnyVW2bwMF7RtPgXAv3nbuzrW9T88j4BCclgvomkaXeG8Goa10SoYQ0cxipCE3j2rAcmcfmUWsTZtRXKH7kNw==",
+      "version": "1.107.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.107.0.tgz",
+      "integrity": "sha512-lkoII5n32NN+zeHvDFoQrE3y0K3RsjKjfywnn1haMVM8a5VA3rpRT9MTe8e3IEiPkNquxs6y7Weh8ThsGAG7EQ==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataTable/OcDataTable.vue
+++ b/packages/core/src/DataTable/OcDataTable.vue
@@ -473,6 +473,7 @@ onMounted(() => {
                 !filterOptions ? 'w-full justify-end' : isSearchExpanded ? 'md:w-fit w-full' : ''
               "
             >
+              <slot name="before-filter-options" :is-search-expanded="isSearchExpanded" />
               <FilterSearch
                 v-if="filterOptions?.search"
                 :is-search-only="!filterOptions.tabs || filterOptions.isSearchOnly"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.107.0",
+    "@orchidui/core": "1.108.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a `before-filter-options` slot to `OcDataTable` so you can render custom content before the search/filter controls. Also bumped `@orchidui/core` and `@orchidui/dashboard` to 1.108.0 and aligned dashboard to the latest core.

- **New Features**
  - `OcDataTable`: new `before-filter-options` slot with `is-search-expanded` prop.

- **Dependencies**
  - `@orchidui/core` → 1.108.0
  - `@orchidui/dashboard` → 1.108.0 (uses `@orchidui/core` 1.108.0)

<sup>Written for commit 0aab4c34e9f5cf4fdb76704ac7c9e83974f02535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

