### PR TITLE
HAP-3033 add custom popperStyle to Select component | update examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.108.0",
+      "version": "1.109.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.108.0",
+      "version": "1.109.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.107.0",
+        "@orchidui/core": "1.108.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.107.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.107.0.tgz",
-      "integrity": "sha512-lkoII5n32NN+zeHvDFoQrE3y0K3RsjKjfywnn1haMVM8a5VA3rpRT9MTe8e3IEiPkNquxs6y7Weh8ThsGAG7EQ==",
+      "version": "1.108.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.108.0.tgz",
+      "integrity": "sha512-W69lf/Uamj7t3++UGs4YNdUf/7KMaFcSc9fVf7Ve1/SX8K37easwqmZ3AuxSELr7cr444Vp9jHAbd2y9tvaRxA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.108.0",
+  "version": "1.109.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/Form/Select/OcSelect.stories.js
+++ b/packages/core/src/Form/Select/OcSelect.stories.js
@@ -1,10 +1,32 @@
 import { Select, Theme } from '@/orchidui-core'
 import { ref } from 'vue'
+import BasicExample from './examples/Basic.vue'
+import BasicRaw from './examples/Basic.vue?raw'
+import FilterableExample from './examples/Filterable.vue'
+import FilterableRaw from './examples/Filterable.vue?raw'
+import MultiSelectExample from './examples/MultiSelect.vue'
+import MultiSelectRaw from './examples/MultiSelect.vue?raw'
+import GroupedOptionsExample from './examples/GroupedOptions.vue'
+import GroupedOptionsRaw from './examples/GroupedOptions.vue?raw'
+import AsyncSearchExample from './examples/AsyncSearch.vue'
+import AsyncSearchRaw from './examples/AsyncSearch.vue?raw'
+import StatesExample from './examples/States.vue'
+import StatesRaw from './examples/States.vue?raw'
+import InlineLabelExample from './examples/InlineLabel.vue'
+import InlineLabelRaw from './examples/InlineLabel.vue?raw'
+import WithAddNewExample from './examples/WithAddNew.vue'
+import WithAddNewRaw from './examples/WithAddNew.vue?raw'
+import CustomWidthExample from './examples/CustomWidth.vue'
+import CustomWidthRaw from './examples/CustomWidth.vue?raw'
+import CustomPlacementExample from './examples/CustomPlacement.vue'
+import CustomPlacementRaw from './examples/CustomPlacement.vue?raw'
 
 export default {
   component: Select,
   tags: ['autodocs'],
   kind: 'leaf',
+  description: 'Dropdown input for single or multi-value selection with search, grouping, and async options.',
+  keywords: ['select', 'dropdown', 'option', 'filter', 'multi-select'],
   use_for: [
     'dropdown selection field',
     'single select input',
@@ -13,60 +35,7 @@ export default {
     'grouped options select',
     'filter field in forms'
   ],
-  parameters: {
-    docs: {
-      description: {
-        component: `
-Select is a dropdown input that supports single value, multi-value, searchable, grouped options, async search, and inline label variants.
-
----
-
-## Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| \`modelValue\` | String\\|Number\\|Array | — | v-model value. Array when \`multiple\` is true |
-| \`options\` | Array | — | Flat: \`[{ label, value }]\` or grouped: \`[{ label, values: [...] }]\` |
-| \`label\` | String | — | Field label shown above the select |
-| \`hint\` | String | — | Helper text shown below |
-| \`placeholder\` | String | \`'Placeholder'\` | Text shown when no value is selected |
-| \`icon\` | String | — | Icon name shown inside the trigger |
-| \`errorMessage\` | String | — | Validation error text shown in red |
-| \`multiple\` | Boolean | \`false\` | Enable multi-value selection |
-| \`isFilterable\` | Boolean | \`false\` | Show a search input inside the dropdown |
-| \`isAsynchronousSearch\` | Boolean | \`false\` | Disable client-side filtering; emits \`onSearchKeywords\` instead |
-| \`isCheckboxes\` | Boolean | \`false\` | Show checkboxes next to options (multi-select UX) |
-| \`isSelectAll\` | Boolean | \`false\` | Show a "Select all" checkbox (requires \`multiple\`) |
-| \`isAddNew\` | Boolean | \`false\` | Show an "Add new" button at the bottom of the dropdown |
-| \`isDisabled\` | Boolean | \`false\` | Disable the select |
-| \`isReadonly\` | Boolean | \`false\` | Read-only (non-interactive) display |
-| \`isLoading\` | Boolean | \`false\` | Show skeleton while options are loading |
-| \`isInlineLabel\` | Boolean | \`false\` | Compact inline label inside the trigger (used in DataTable per-page) |
-| \`isTransparent\` | Boolean | \`false\` | Remove border and background |
-| \`isSlim\` | Boolean | \`false\` | Reduced height trigger |
-| \`isClearable\` | Boolean | \`false\` | Show a clear (×) button when a value is selected |
-| \`hideChevron\` | Boolean | \`false\` | Hide the dropdown arrow icon |
-| \`maxOptionAllowed\` | Number | — | Maximum number of selections (multi-select only) |
-| \`searchKeywords\` | String | — | External control of the search query |
-
----
-
-## Events
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| \`update:modelValue\` | value | Selected value changed |
-| \`onSearchKeywords\` | query | Emitted on search input change when \`isAsynchronousSearch\` is true |
-| \`addNew\` | — | "Add new" button was clicked |
-| \`cleared\` | — | Clear button was clicked |
-| \`close\` | — | Dropdown closed |
-| \`toggle\` | — | Dropdown opened or closed |
-| \`loadMore\` | — | User scrolled to the bottom of the list |
-| \`max-option-allowed-set\` | — | User tried to select more than \`maxOptionAllowed\` |
-        `.trim()
-      }
-    }
-  }
+  understand_with: ['FormBuilder', 'DataTable', 'FilterForm', 'Chip', 'Dropdown', 'Option']
 }
 
 // ── Playground ────────────────────────────────────────────────────────────────
@@ -79,6 +48,11 @@ export const Playground = {
     isLoading:    { control: 'boolean' },
     multiple:     { control: 'boolean' },
     isCheckboxes: { control: 'boolean' },
+    placement:    {
+      control: 'select',
+      options: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'left', 'right'],
+      description: 'Popper placement — bottom-start = bottom-left'
+    },
     label:        { control: 'text' },
     hint:         { control: 'text' },
     placeholder:  { control: 'text' },
@@ -91,6 +65,7 @@ export const Playground = {
     isLoading:    false,
     multiple:     false,
     isCheckboxes: false,
+    placement:    'bottom-end',
     label:        'Country',
     hint:         '',
     placeholder:  'Select a country...',
@@ -117,464 +92,102 @@ export const Playground = {
   })
 }
 
-// ── Basic ─────────────────────────────────────────────────────────────────────
-
 export const Basic = {
   description: 'Single-value select with label and hint. v-model receives the selected option value (not the option object).',
   highlights: ['v-model — selected value (not the option object)', 'options — array of { label, value }', 'hint prop — helper text'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const value = ref(null)
-
-const options = [
-  { label: 'Indonesia', value: 'ID' },
-  { label: 'Singapore', value: 'SG' },
-  { label: 'Malaysia',  value: 'MY' }
-]
-</script>
-
-<template>
-  <div class="w-[300px] h-[250px]">
-    <Select
-      v-model="value"
-      label="Country"
-      hint="Select your country."
-      placeholder="Select a country..."
-      :options="options"
-    />
-  </div>
-</template>`,
+  code: BasicRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const value = ref(null)
-      const options = [
-        { label: 'Indonesia', value: 'ID' },
-        { label: 'Singapore', value: 'SG' },
-        { label: 'Malaysia',  value: 'MY' }
-      ]
-      return { value, options }
-    },
-    template: `
-      <div class="p-6 h-[250px]">
-        <Select v-model="value" label="Country" placeholder="Select a country..." :options="options" />
-      </div>
-    `
+    components: { BasicExample },
+    template: `<div class="p-6"><BasicExample /></div>`
   })
 }
-
-// ── Filterable ────────────────────────────────────────────────────────────────
 
 export const Filterable = {
   description: 'Searchable dropdown — shows a search input inside the menu. For async search, set is-asynchronous-search and listen to onSearchKeywords.',
   highlights: ['is-filterable — client-side search', 'is-asynchronous-search — disables client-side filter, emits onSearchKeywords', 'onSearchKeywords event — debounce and fetch in parent'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const value = ref(null)
-
-const options = [
-  { label: 'Australia', value: 'AU' },
-  { label: 'Canada',    value: 'CA' },
-  { label: 'France',    value: 'FR' },
-  { label: 'Germany',   value: 'DE' },
-  { label: 'Indonesia', value: 'ID' },
-  { label: 'Japan',     value: 'JP' },
-  { label: 'Singapore', value: 'SG' },
-  { label: 'UK',        value: 'GB' },
-  { label: 'USA',       value: 'US' }
-]
-</script>
-
-<template>
-  <div class="w-[300px] h-[350px]">
-    <Select
-      v-model="value"
-      label="Country"
-      placeholder="Search countries..."
-      is-filterable
-      :options="options"
-    />
-  </div>
-</template>`,
+  code: FilterableRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const value = ref(null)
-      const options = [
-        { label: 'Australia', value: 'AU' }, { label: 'Canada', value: 'CA' },
-        { label: 'France', value: 'FR' }, { label: 'Germany', value: 'DE' },
-        { label: 'Indonesia', value: 'ID' }, { label: 'Japan', value: 'JP' },
-        { label: 'Singapore', value: 'SG' }, { label: 'UK', value: 'GB' }, { label: 'USA', value: 'US' }
-      ]
-      return { value, options }
-    },
-    template: `
-      <div class="p-6 h-[350px]">
-        <Select v-model="value" label="Country" placeholder="Search countries..." is-filterable :options="options" />
-      </div>
-    `
+    components: { FilterableExample },
+    template: `<div class="p-6"><FilterableExample /></div>`
   })
 }
-
-// ── Multi-select ──────────────────────────────────────────────────────────────
 
 export const MultiSelect = {
   description: 'Multi-value select. v-model is an array. Selected values appear as Chip tags. is-checkboxes shows a checkbox per option.',
   highlights: ['multiple — enables multi-select', 'v-model is string[]', 'is-checkboxes — checkbox UX', 'is-select-all — select/clear all button', 'max-option-allowed — cap selections'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const values = ref([])
-
-const options = [
-  { label: 'Design',      value: 'design' },
-  { label: 'Engineering', value: 'eng' },
-  { label: 'Marketing',   value: 'mkt' },
-  { label: 'Sales',       value: 'sales' },
-  { label: 'Support',     value: 'support' }
-]
-</script>
-
-<template>
-  <div class="w-[350px] h-[300px]">
-    <Select
-      v-model="values"
-      label="Departments"
-      placeholder="Select departments..."
-      multiple
-      is-filterable
-      is-checkboxes
-      is-select-all
-      :options="options"
-    />
-  </div>
-</template>`,
+  code: MultiSelectRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const values = ref([])
-      const options = [
-        { label: 'Design', value: 'design' }, { label: 'Engineering', value: 'eng' },
-        { label: 'Marketing', value: 'mkt' }, { label: 'Sales', value: 'sales' },
-        { label: 'Support', value: 'support' }
-      ]
-      return { values, options }
-    },
-    template: `
-      <div class="p-6 h-[300px]">
-        <Select v-model="values" label="Departments" placeholder="Select departments..." multiple is-filterable is-checkboxes is-select-all :options="options" />
-      </div>
-    `
+    components: { MultiSelectExample },
+    template: `<div class="p-6"><MultiSelectExample /></div>`
   })
 }
-
-// ── Grouped Options ───────────────────────────────────────────────────────────
 
 export const GroupedOptions = {
   description: 'Options organized into labeled groups. Pass objects with { label, values: [...] } instead of flat options. Flat and grouped can be mixed.',
   highlights: ['grouped format: { label: string, values: Option[] }', 'flat and grouped can be mixed in same array'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const value = ref(null)
-
-const options = [
-  { label: 'Most Popular', value: 'popular' },
-  {
-    label: 'Southeast Asia',
-    values: [
-      { label: 'Indonesia', value: 'ID' },
-      { label: 'Singapore', value: 'SG' },
-      { label: 'Malaysia',  value: 'MY' }
-    ]
-  },
-  {
-    label: 'Europe',
-    values: [
-      { label: 'Germany', value: 'DE' },
-      { label: 'France',  value: 'FR' },
-      { label: 'UK',      value: 'GB' }
-    ]
-  }
-]
-</script>
-
-<template>
-  <div class="w-[300px] h-[400px]">
-    <Select
-      v-model="value"
-      label="Region"
-      placeholder="Select region..."
-      is-filterable
-      :options="options"
-    />
-  </div>
-</template>`,
+  code: GroupedOptionsRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const value = ref(null)
-      const options = [
-        { label: 'Most Popular', value: 'popular' },
-        { label: 'Southeast Asia', values: [
-          { label: 'Indonesia', value: 'ID' }, { label: 'Singapore', value: 'SG' },
-          { label: 'Malaysia', value: 'MY' }
-        ]},
-        { label: 'Europe', values: [
-          { label: 'Germany', value: 'DE' }, { label: 'France', value: 'FR' }
-        ]}
-      ]
-      return { value, options }
-    },
-    template: `
-      <div class="p-6 h-[400px]">
-        <Select v-model="value" label="Region" placeholder="Select region..." is-filterable :options="options" />
-      </div>
-    `
+    components: { GroupedOptionsExample },
+    template: `<div class="p-6"><GroupedOptionsExample /></div>`
   })
 }
-
-// ── Async Search ──────────────────────────────────────────────────────────────
 
 export const AsyncSearch = {
   description: 'Server-side search. Set is-asynchronous-search to disable client-side filtering. Listen to onSearchKeywords, debounce, then replace options with the server response.',
   highlights: ['is-asynchronous-search — disables client-side filter', 'onSearchKeywords event — (query: string)', 'is-loading — show skeleton while fetching', 'replace options ref after fetch'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const value   = ref(null)
-const options = ref([])
-const isLoading = ref(false)
-
-let timer = null
-function onSearch(query) {
-  isLoading.value = true
-  clearTimeout(timer)
-  timer = setTimeout(async () => {
-    // Replace with real API call
-    options.value = [
-      { label: \`Result for "\${query}" 1\`, value: '1' },
-      { label: \`Result for "\${query}" 2\`, value: '2' }
-    ]
-    isLoading.value = false
-  }, 400)
-}
-</script>
-
-<template>
-  <div class="w-[320px] h-[280px]">
-    <Select
-      v-model="value"
-      label="Search users"
-      placeholder="Type to search..."
-      is-filterable
-      is-asynchronous-search
-      :is-loading="isLoading"
-      :options="options"
-      @on-search-keywords="onSearch"
-    />
-  </div>
-</template>`,
+  code: AsyncSearchRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const value     = ref(null)
-      const options   = ref([])
-      const isLoading = ref(false)
-      let timer = null
-      function onSearch(query) {
-        if (!query) { options.value = []; return }
-        isLoading.value = true
-        clearTimeout(timer)
-        timer = setTimeout(() => {
-          options.value = [
-            { label: `Result for "${query}" A`, value: '1' },
-            { label: `Result for "${query}" B`, value: '2' },
-            { label: `Result for "${query}" C`, value: '3' }
-          ]
-          isLoading.value = false
-        }, 500)
-      }
-      return { value, options, isLoading, onSearch }
-    },
-    template: `
-      <div class="p-6 h-[280px]">
-        <Select v-model="value" label="Search users" placeholder="Type to search..." is-filterable is-asynchronous-search :is-loading="isLoading" :options="options" @on-search-keywords="onSearch" />
-      </div>
-    `
+    components: { AsyncSearchExample },
+    template: `<div class="p-6"><AsyncSearchExample /></div>`
   })
 }
-
-// ── Disabled & States ─────────────────────────────────────────────────────────
 
 export const States = {
   description: 'All interactive states: disabled, readonly, with error, and clearable.',
   highlights: ['is-disabled', 'is-readonly', 'errorMessage prop', 'is-clearable — shows × button'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const options = [
-  { label: 'Singapore', value: 'SG' },
-  { label: 'Malaysia',  value: 'MY' }
-]
-</script>
-
-<template>
-  <div class="flex flex-col gap-6 w-[300px] h-[600px]">
-    <Select
-      model-value="SG"
-      label="Disabled"
-      is-disabled
-      :options="options"
-    />
-    <Select
-      model-value="MY"
-      label="Read-only"
-      is-readonly
-      :options="options"
-    />
-    <Select
-      :model-value="null"
-      label="With error"
-      error-message="Please select a country."
-      :options="options"
-    />
-    <Select
-      model-value="SG"
-      label="Clearable"
-      is-clearable
-      :options="options"
-    />
-  </div>
-</template>`,
+  code: StatesRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const options = [
-        { label: 'Singapore', value: 'SG' },
-        { label: 'Malaysia',  value: 'MY' }
-      ]
-      const v = ref('SG')
-      return { options, v }
-    },
-    template: `
-      <div class="p-6 flex flex-col gap-6 w-[300px]">
-        <Select model-value="SG"  label="Disabled"    is-disabled   :options="options" />
-        <Select model-value="MY"  label="Read-only"   is-readonly   :options="options" />
-        <Select :model-value="null" label="With error" error-message="Please select a country." :options="options" />
-        <Select v-model="v"       label="Clearable"   is-clearable  :options="options" />
-      </div>
-    `
+    components: { StatesExample },
+    template: `<div class="p-6"><StatesExample /></div>`
   })
 }
-
-// ── Inline Label ──────────────────────────────────────────────────────────────
 
 export const InlineLabel = {
   description: 'Compact inline label inside the trigger — used in table toolbars (e.g. "10 per page").',
   highlights: ['is-inline-label — label sits inside the trigger', 'is-slim — reduced height', 'common in DataTable per-page dropdown'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const perPage = ref(10)
-
-const options = [
-  { label: '10', value: 10 },
-  { label: '25', value: 25 },
-  { label: '50', value: 50 },
-  { label: '100', value: 100 }
-]
-</script>
-
-<template>
-  <Select
-    v-model="perPage"
-    label="Per page"
-    is-inline-label
-    is-slim
-    :options="options"
-  />
-</template>`,
+  code: InlineLabelRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const perPage = ref(10)
-      const options = [
-        { label: '10', value: 10 },
-        { label: '25', value: 25 },
-        { label: '50', value: 50 },
-        { label: '100', value: 100 }
-      ]
-      return { perPage, options }
-    },
-    template: `
-      <div class="p-6">
-        <Select v-model="perPage" label="Per page" is-inline-label is-slim :options="options" />
-      </div>
-    `
+    components: { InlineLabelExample },
+    template: `<div class="p-6"><InlineLabelExample /></div>`
   })
 }
-
-// ── Add New ───────────────────────────────────────────────────────────────────
 
 export const WithAddNew = {
   description: 'Shows an "Add new" button at the bottom of the dropdown. Emit addNew to open a creation flow.',
   highlights: ['is-add-new prop', 'addNew event — triggered on button click'],
-  code: `<script setup>
-import { ref } from 'vue'
-import { Select } from '@orchidui/core'
-
-const value   = ref(null)
-const options = ref([
-  { label: 'Category A', value: 'a' },
-  { label: 'Category B', value: 'b' }
-])
-
-function onAddNew() {
-  const n = options.value.length + 1
-  options.value.push({ label: \`Category \${n}\`, value: \`cat\${n}\` })
-}
-</script>
-
-<template>
-  <div class="w-[300px] h-[300px]">
-    <Select
-      v-model="value"
-      label="Category"
-      placeholder="Select or create..."
-      is-add-new
-      :options="options"
-      @add-new="onAddNew"
-    />
-  </div>
-</template>`,
+  code: WithAddNewRaw,
   render: () => ({
-    components: { Select },
-    setup() {
-      const value   = ref(null)
-      const options = ref([
-        { label: 'Category A', value: 'a' },
-        { label: 'Category B', value: 'b' }
-      ])
-      const onAddNew = () => {
-        const n = options.value.length + 1
-        options.value.push({ label: `Category ${n}`, value: `cat${n}` })
-      }
-      return { value, options, onAddNew }
-    },
-    template: `
-      <div class="p-6 h-[300px]">
-        <Select v-model="value" label="Category" placeholder="Select or create..." is-add-new :options="options" @add-new="onAddNew" />
-      </div>
-    `
+    components: { WithAddNewExample },
+    template: `<div class="p-6"><WithAddNewExample /></div>`
+  })
+}
+
+export const CustomWidth = {
+  description: 'Pass popperStyle to override the dropdown width when the menu should be wider or narrower than the trigger.',
+  highlights: ['popperStyle — inline styles on the dropdown menu', "e.g. { width: '500px' }", 'menu defaults to the trigger width when popperStyle has no width'],
+  code: CustomWidthRaw,
+  render: () => ({
+    components: { CustomWidthExample },
+    template: `<div class="p-6"><CustomWidthExample /></div>`
+  })
+}
+
+export const CustomPlacement = {
+  description: 'Control where the dropdown opens relative to the trigger. Use bottom-start for bottom-left alignment.',
+  highlights: ['placement — Popper.js placement string', 'bottom-start — bottom-left', 'bottom-end — bottom-right (default)'],
+  code: CustomPlacementRaw,
+  render: () => ({
+    components: { CustomPlacementExample },
+    template: `<div class="p-6"><CustomPlacementExample /></div>`
   })
 }

--- a/packages/core/src/Form/Select/OcSelect.vue
+++ b/packages/core/src/Form/Select/OcSelect.vue
@@ -93,7 +93,23 @@ const props = defineProps({
     type: Object,
     default: () => ({})
   },
-  /** Props forwarded to the underlying Popper/Dropdown component (e.g. placement). */
+  /**
+   * Popper placement for the dropdown menu.
+   * Common values: `'bottom-start'` (bottom-left), `'bottom-end'`, `'top-start'`, `'top-end'`, `'left'`, `'right'`.
+   */
+  placement: {
+    type: String,
+    default: 'bottom-end'
+  },
+  /**
+   * Inline styles applied to the popper (dropdown menu) element.
+   * Overrides the default trigger-matched width — e.g. `{ width: '320px', maxWidth: '320px' }`.
+   */
+  popperStyle: {
+    type: Object,
+    default: () => ({})
+  },
+  /** Props forwarded to the underlying Popper/Dropdown component. */
   popperOptions: {
     type: Object,
     default: () => ({})
@@ -275,8 +291,15 @@ watch(isDropdownOpened, (value) => {
 })
 
 const maxPopperWidth = ref('100%')
-const popperStyle = computed(() => {
-  return { maxWidth: maxPopperWidth.value }
+const mergedPopperStyle = computed(() => {
+  const custom = props.popperStyle || {}
+  // Only cap the menu to the trigger width when the caller hasn't set an explicit width.
+  const hasCustomWidth = custom.width != null || custom.maxWidth != null
+
+  return {
+    ...(hasCustomWidth ? {} : { maxWidth: maxPopperWidth.value }),
+    ...custom
+  }
 })
 const onUpdateDropdown = () => {
   emit('toggle')
@@ -322,11 +345,15 @@ const loadMore = (e) => {
   }
 }
 
-watch(() => props.modelValue, () => {
-  hasAi.value = false
-}, {
-  once: true,
-})
+watch(
+  () => props.modelValue,
+  () => {
+    hasAi.value = false
+  },
+  {
+    once: true
+  }
+)
 
 defineExpose({
   dropdownRef
@@ -357,8 +384,8 @@ defineExpose({
       ]"
       :distance="4"
       popper-class="w-full"
-      placement="bottom-end"
-      :popper-style="popperStyle"
+      :placement="placement"
+      :popper-style="mergedPopperStyle"
       :popper-options="popperOptions"
       :is-disabled="isDisabled || isReadonly"
       :menu-classes="menuClasses"
@@ -366,7 +393,7 @@ defineExpose({
       @scroll="loadMore"
     >
       <div
-        class="border min-h-[36px] input-shadow transition-all duration-[250ms] ease-out w-full px-3 flex justify-between items-center  focus-within:bg-white cursor-pointer gap-x-3 rounded"
+        class="border min-h-[36px] input-shadow transition-all duration-[250ms] ease-out w-full px-3 flex justify-between items-center focus-within:bg-white cursor-pointer gap-x-3 rounded"
         :class="[
           dropdownClasses,
           {
@@ -381,7 +408,7 @@ defineExpose({
           }
         ]"
       >
-        <div v-if="multiple" class="flex flex-wrap gap-2 overflow-hidden">
+        <div v-if="multiple" class="flex overflow-hidden flex-wrap gap-2">
           <slot name="selection">
             <Chip
               v-for="option in maxVisibleOptions
@@ -420,7 +447,7 @@ defineExpose({
         </template>
         <template v-else>
           <span
-            class="whitespace-nowrap flex gap-x-3 items-center overflow-hidden"
+            class="flex overflow-hidden gap-x-3 items-center whitespace-nowrap"
             :class="selectTextClass"
           >
             <Icon v-if="icon" :name="icon" width="16" height="16" />
@@ -436,7 +463,7 @@ defineExpose({
         </template>
         <Icon
           v-if="modelValue && isClearable"
-          class="text-oc-text-400 ml-auto transition-all shrink-0 duration-500 hover:rotate-90"
+          class="ml-auto transition-all duration-500 text-oc-text-400 shrink-0 hover:rotate-90"
           width="16"
           height="16"
           name="x"
@@ -444,7 +471,7 @@ defineExpose({
         />
         <Icon
           v-if="!hideChevron"
-          class="w-5 h-5 transition-all shrink-0 duration-500"
+          class="w-5 h-5 transition-all duration-500 shrink-0"
           :class="{
             '-rotate-180': isDropdownOpened,
             'text-oc-text-400': !dropdownClasses
@@ -460,7 +487,7 @@ defineExpose({
               (isFilterable && !isInlineSearch) ||
               (isFilterable && isInlineSearch && localValueOption)
             "
-            class="sticky px-3 pt-3 top-0 z-10 bg-white"
+            class="sticky top-0 z-10 px-3 pt-3 bg-white"
           >
             <Input
               ref="searchInputRef"
@@ -476,7 +503,7 @@ defineExpose({
           </div>
 
           <div
-            class="flex px-3 pb-3 flex-col gap-y-2"
+            class="flex flex-col gap-y-2 px-3 pb-3"
             :class="{ 'pt-3': !isFilterable || (isInlineSearch && !localValueOption) }"
           >
             <Option
@@ -508,7 +535,7 @@ defineExpose({
               />
               <!-- Empty div to trigger the slot -->
               <slot name="empty">
-                <div v-if="!filterableOptions.length" class="text-sm text-oc-text-300 text-center">
+                <div v-if="!filterableOptions.length" class="text-sm text-center text-oc-text-300">
                   No data to display
                 </div>
               </slot>

--- a/packages/core/src/Form/Select/examples/AsyncSearch.vue
+++ b/packages/core/src/Form/Select/examples/AsyncSearch.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value     = ref(null)
+const options   = ref([])
+const isLoading = ref(false)
+
+let timer = null
+
+function onSearch(query) {
+  if (!query) {
+    options.value = []
+    return
+  }
+
+  isLoading.value = true
+  clearTimeout(timer)
+  timer = setTimeout(() => {
+    options.value = [
+      { label: `Result for "${query}" A`, value: '1' },
+      { label: `Result for "${query}" B`, value: '2' },
+      { label: `Result for "${query}" C`, value: '3' }
+    ]
+    isLoading.value = false
+  }, 500)
+}
+</script>
+
+<template>
+  <div class="w-[320px] h-[280px]">
+    <Select
+      v-model="value"
+      label="Search users"
+      placeholder="Type to search..."
+      is-filterable
+      is-asynchronous-search
+      :is-loading="isLoading"
+      :options="options"
+      @on-search-keywords="onSearch"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/Basic.vue
+++ b/packages/core/src/Form/Select/examples/Basic.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value = ref(null)
+
+const options = [
+  { label: 'Indonesia', value: 'ID' },
+  { label: 'Singapore', value: 'SG' },
+  { label: 'Malaysia',  value: 'MY' }
+]
+</script>
+
+<template>
+  <div class="w-[300px] h-[250px]">
+    <Select
+      v-model="value"
+      label="Country"
+      hint="Select your country."
+      placeholder="Select a country..."
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/CustomPlacement.vue
+++ b/packages/core/src/Form/Select/examples/CustomPlacement.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@/orchidui-core'
+
+const value = ref(null)
+
+const options = [
+  { label: 'Indonesia', value: 'ID' },
+  { label: 'Singapore', value: 'SG' },
+  { label: 'Malaysia', value: 'MY' }
+]
+</script>
+
+<template>
+  <div class="relative h-[280px] flex items-end justify-end p-6">
+    <div class="w-[240px]">
+      <Select
+        v-model="value"
+        label="Country"
+        :popper-style="{ width: '500px' }"
+        placement="bottom-start"
+        placeholder="Bottom left..."
+        :options="options"
+      />
+    </div>
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/CustomWidth.vue
+++ b/packages/core/src/Form/Select/examples/CustomWidth.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@/orchidui-core'
+
+const value = ref(null)
+
+const options = [
+  { label: 'Republic of Indonesia', value: 'ID' },
+  { label: 'Republic of Singapore', value: 'SG' },
+  { label: 'Kingdom of Thailand', value: 'TH' },
+  { label: 'Socialist Republic of Vietnam', value: 'VN' }
+]
+</script>
+
+<template>
+  <div class="w-[220px] h-[320px]">
+    <Select
+      v-model="value"
+      label="Country"
+      :popper-style="{ width: '500px' }"
+      placeholder="Select..."
+      is-filterable
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/Filterable.vue
+++ b/packages/core/src/Form/Select/examples/Filterable.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value = ref(null)
+
+const options = [
+  { label: 'Australia', value: 'AU' },
+  { label: 'Canada',    value: 'CA' },
+  { label: 'France',    value: 'FR' },
+  { label: 'Germany',   value: 'DE' },
+  { label: 'Indonesia', value: 'ID' },
+  { label: 'Japan',     value: 'JP' },
+  { label: 'Singapore', value: 'SG' },
+  { label: 'UK',        value: 'GB' },
+  { label: 'USA',       value: 'US' }
+]
+</script>
+
+<template>
+  <div class="w-[300px] h-[350px]">
+    <Select
+      v-model="value"
+      label="Country"
+      placeholder="Search countries..."
+      is-filterable
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/GroupedOptions.vue
+++ b/packages/core/src/Form/Select/examples/GroupedOptions.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value = ref(null)
+
+const options = [
+  { label: 'Most Popular', value: 'popular' },
+  {
+    label: 'Southeast Asia',
+    values: [
+      { label: 'Indonesia', value: 'ID' },
+      { label: 'Singapore', value: 'SG' },
+      { label: 'Malaysia',  value: 'MY' }
+    ]
+  },
+  {
+    label: 'Europe',
+    values: [
+      { label: 'Germany', value: 'DE' },
+      { label: 'France',  value: 'FR' },
+      { label: 'UK',      value: 'GB' }
+    ]
+  }
+]
+</script>
+
+<template>
+  <div class="w-[300px] h-[400px]">
+    <Select
+      v-model="value"
+      label="Region"
+      placeholder="Select region..."
+      is-filterable
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/InlineLabel.vue
+++ b/packages/core/src/Form/Select/examples/InlineLabel.vue
@@ -1,0 +1,23 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const perPage = ref(10)
+
+const options = [
+  { label: '10', value: 10 },
+  { label: '25', value: 25 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 }
+]
+</script>
+
+<template>
+  <Select
+    v-model="perPage"
+    label="Per page"
+    is-inline-label
+    is-slim
+    :options="options"
+  />
+</template>

--- a/packages/core/src/Form/Select/examples/MultiSelect.vue
+++ b/packages/core/src/Form/Select/examples/MultiSelect.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const values = ref([])
+
+const options = [
+  { label: 'Design',      value: 'design' },
+  { label: 'Engineering', value: 'eng' },
+  { label: 'Marketing',   value: 'mkt' },
+  { label: 'Sales',       value: 'sales' },
+  { label: 'Support',     value: 'support' }
+]
+</script>
+
+<template>
+  <div class="w-[350px] h-[300px]">
+    <Select
+      v-model="values"
+      label="Departments"
+      placeholder="Select departments..."
+      multiple
+      is-filterable
+      is-checkboxes
+      is-select-all
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/States.vue
+++ b/packages/core/src/Form/Select/examples/States.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value = ref('SG')
+
+const options = [
+  { label: 'Singapore', value: 'SG' },
+  { label: 'Malaysia',  value: 'MY' }
+]
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 w-[300px]">
+    <Select
+      model-value="SG"
+      label="Disabled"
+      is-disabled
+      :options="options"
+    />
+    <Select
+      model-value="MY"
+      label="Read-only"
+      is-readonly
+      :options="options"
+    />
+    <Select
+      :model-value="null"
+      label="With error"
+      error-message="Please select a country."
+      :options="options"
+    />
+    <Select
+      v-model="value"
+      label="Clearable"
+      is-clearable
+      :options="options"
+    />
+  </div>
+</template>

--- a/packages/core/src/Form/Select/examples/WithAddNew.vue
+++ b/packages/core/src/Form/Select/examples/WithAddNew.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { ref } from 'vue'
+import { Select } from '@orchidui/core'
+
+const value   = ref(null)
+const options = ref([
+  { label: 'Category A', value: 'a' },
+  { label: 'Category B', value: 'b' }
+])
+
+function onAddNew() {
+  const n = options.value.length + 1
+  options.value.push({ label: `Category ${n}`, value: `cat${n}` })
+}
+</script>
+
+<template>
+  <div class="w-[300px] h-[300px]">
+    <Select
+      v-model="value"
+      label="Category"
+      placeholder="Select or create..."
+      is-add-new
+      :options="options"
+      @add-new="onAddNew"
+    />
+  </div>
+</template>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.108.0",
+  "version": "1.109.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.108.0",
+    "@orchidui/core": "1.109.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds configurable dropdown width and placement to the `Select` component to support the Web POS currency selector (HAP-3033). Prevents the "Search" text from being cut off and lets the menu align next to the location selector.

- **New Features**
  - `Select` adds `popperStyle` to style the dropdown; set a custom width (e.g. `{ width: '500px' }`).
  - `Select` adds `placement` (default `bottom-end`) to control menu alignment.
  - Menu keeps the trigger’s width unless `popperStyle` sets `width` or `maxWidth`.
  - Storybook cleaned up with focused examples, including Custom Width and Placement.

- **Dependencies**
  - Bump `@orchidui/core` to `1.109.0` and `@orchidui/dashboard` to `1.109.0`.

<sup>Written for commit 9dabfcf9a0c24d2e590f49ff2675802b84bf5393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

