### PR TITLE
bugfix/HIT-18189 fix table and text editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11165,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@orchidui/core",
-      "version": "1.109.0",
+      "version": "1.110.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -11181,10 +11181,10 @@
     },
     "packages/dashboard": {
       "name": "@orchidui/dashboard",
-      "version": "1.109.0",
+      "version": "1.110.0",
       "license": "MIT",
       "dependencies": {
-        "@orchidui/core": "1.108.0",
+        "@orchidui/core": "1.109.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "lottie-web": "^5.12.2",
@@ -11194,9 +11194,9 @@
       }
     },
     "packages/dashboard/node_modules/@orchidui/core": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.108.0.tgz",
-      "integrity": "sha512-W69lf/Uamj7t3++UGs4YNdUf/7KMaFcSc9fVf7Ve1/SX8K37easwqmZ3AuxSELr7cr444Vp9jHAbd2y9tvaRxA==",
+      "version": "1.109.0",
+      "resolved": "https://registry.npmjs.org/@orchidui/core/-/core-1.109.0.tgz",
+      "integrity": "sha512-7L8xQKCrhPyJd5fraKIFACEuDDuTdt8NSPuRDHaXpK+cVpnX9BLfKNNWPuQ2be4Jh+j6d6FfUS/XGZsoZJmtDA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/core",
   "description": "Orchid UI, Library Vue 3 tailwind css",
-  "version": "1.109.0",
+  "version": "1.110.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/packages/core/src/DataDisplay/Table/OcTable.vue
+++ b/packages/core/src/DataDisplay/Table/OcTable.vue
@@ -138,7 +138,7 @@ onMounted(() => onScroll())
     ref="scrollTable"
     class="flex text-oc-text flex-col border-oc-gray-200 isolate z-10"
     :class="[
-      isSticky ? 'overflow-x-auto' : 'overflow-hidden',
+      isSticky ? 'overflow-x-auto hidden-scrollbar' : 'overflow-hidden',
       isResponsive ? 'rounded' : 'md:rounded',
       isBorderless ? '' : 'border'
     ]"
@@ -323,3 +323,14 @@ onMounted(() => onScroll())
     <slot name="after" />
   </div>
 </template>
+
+<style scoped lang="scss">
+.hidden-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+</style>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orchidui/dashboard",
   "description": "Orchid Dashboard UI , Dashboard Ui Library Vue 3 tailwind css",
-  "version": "1.109.0",
+  "version": "1.110.0",
   "type": "module",
   "scripts": {
     "build": "vite build"
@@ -33,7 +33,7 @@
     "rollup": "npm:@rollup/wasm-node"
   },
   "dependencies": {
-    "@orchidui/core": "1.109.0",
+    "@orchidui/core": "1.110.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "lottie-web": "^5.12.2",

--- a/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.vue
+++ b/packages/dashboard/src/Dashboard/TextEditor/OcTextEditor.vue
@@ -121,6 +121,17 @@ const loaded = ref(false)
 // need for upload to server
 const base64Images = ref(props.image)
 
+const hasNonTextContent = (element) =>
+  element.querySelector('img, iframe, video, hr, table')
+
+const isEditorContentEmpty = (html) => {
+  const dom = document.createElement('div')
+  dom.innerHTML = html
+  const isEmpty = !dom.innerText?.trim() && !hasNonTextContent(dom)
+  dom.remove()
+  return isEmpty
+}
+
 const checkStates = (value) => {
   isUndoActive.value = quill.value.getQuill().history.stack.undo.length > 0
   isRedoActive.value = quill.value.getQuill().history.stack.redo.length > 0
@@ -130,21 +141,16 @@ const checkStates = (value) => {
   isBlockquoteActive.value = quill.value.getQuill().getFormat().blockquote
   activeListFormat.value = quill.value.getQuill().getFormat().list
   activeAlign.value = quill.value.getQuill().getFormat().align
-  // check if innerText null remove tags
-  let domTest = document.createElement('div')
-  domTest.innerHTML = value
 
   if (!loaded.value) {
     return
   }
 
-  if (!domTest.innerText) {
-    // reset
+  if (isEditorContentEmpty(value)) {
     emit('update:modelValue', '')
   } else {
     emit('update:modelValue', value || '')
   }
-  domTest.remove()
 }
 
 const addDivider = () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes media-only content being cleared in `OcTextEditor`, which caused the Online Store section to disappear when text was empty (HIT-18189). Also hides the horizontal scrollbar for sticky tables.

- **Bug Fixes**
  - `OcTextEditor`: Treat images, videos, iframes, dividers, and tables as content so the editor doesn’t emit an empty value when text is removed; media no longer disappears.
  - `OcTable`: Add `hidden-scrollbar` for sticky state to keep horizontal scroll without showing the scrollbar.

- **Dependencies**
  - Bump `@orchidui/core` and `@orchidui/dashboard` to `1.110.0` and align `@orchidui/core` dependency in `@orchidui/dashboard`; update lockfile.

<sup>Written for commit 6c99588c1df9ca32ff0ddb1bbbd37f6e8d3cec2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hit-pay/orchid/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

